### PR TITLE
Extend README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,7 @@
 
 An MCP server for Hydrolix.
 
-## Features
-
-### Tools
+## Tools
 
 * `run_select_query`
   - Execute SQL queries on your Hydrolix cluster.
@@ -19,13 +17,66 @@ An MCP server for Hydrolix.
   - List all tables in a database.
   - Input: `database` (string): The name of the database.
 
+## Effective Usage
+
+Due to the wide variety in LLM architectures, not all models will proactively use the tools above, and few will use them effectively without guidance, even with the carefully-constructed tool descriptions provided to the model. To get the best results out of your model while using the Hydrolix MCP server, we recommend the following:
+
+* Refer to your Hydrolix database by name and request tool usage in your prompts (e.g., "Using MCP tools to access my Hydrolix database, please ...")
+  - This encourages the model to use the MCP tools available and minimizes hallucinations.
+* Include time ranges in your prompts (e.g., "Between December 5 2023 and January 18 2024, ...") and specifically request that the output be ordered by timestamp.
+  - This prompts the model to write more efficient queries that take advantage of [primary key optimizations](https://hydrolix.io/blog/optimizing-latest-n-row-queries/)
+
 ## Configuration
+
+The Hydrolix MCP server is configured using a standard MCP server entry. Consult your client's documentation for specific instructions on where to find or declare MCP servers. An example setup using Claude Desktop is documented below.
+
+The recommended way to launch the Hydrolix MCP server is via the [`uv` project manager](https://github.com/astral-sh/uv), which will manage installing all other dependencies in an isolated environment.
+
+MCP Server definition (JSON):
+
+```json
+{
+  "command": "uv",
+  "args": [
+    "run",
+    "--with",
+    "mcp-hydrolix",
+    "--python",
+    "3.13",
+    "mcp-hydrolix"
+  ],
+  "env": {
+    "HYDROLIX_HOST": "<hydrolix-host>",
+    "HYDROLIX_USER": "<hydrolix-user>",
+    "HYDROLIX_PASSWORD": "<hydrolix-password>",
+  }
+}
+```
+
+MCP Server definition (YAML):
+
+```yaml
+command: uv
+args:
+- run
+- --with
+- mcp-hydrolix
+- --python
+- "3.13"
+- mcp-hydrolix
+env:
+  HYDROLIX_HOST: <hydrolix-host>
+  HYDROLIX_USER: <hydrolix-user>
+  HYDROLIX_PASSWORD: <hydrolix-password>
+```
+
+## Configuration Example (Claude Desktop)
 
 1. Open the Claude Desktop configuration file located at:
    - On macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
    - On Windows: `%APPDATA%/Claude/claude_desktop_config.json`
 
-2. Add the following:
+2. Add a `mcp-hydrolix` server entry to the `mcpServers` config block:
 
 ```json
 {
@@ -42,28 +93,23 @@ An MCP server for Hydrolix.
       ],
       "env": {
         "HYDROLIX_HOST": "<hydrolix-host>",
-        "HYDROLIX_PORT": "<hydrolix-port>",
         "HYDROLIX_USER": "<hydrolix-user>",
         "HYDROLIX_PASSWORD": "<hydrolix-password>",
-        "HYDROLIX_SECURE": "true",
-        "HYDROLIX_VERIFY": "true",
-        "HYDROLIX_CONNECT_TIMEOUT": "30",
-        "HYDROLIX_SEND_RECEIVE_TIMEOUT": "30"
       }
     }
   }
 }
 ```
 
-Update the environment variables to point to your own Hydrolix service.
+3. Update the environment variable definitions to point to your Hydrolix cluster.
 
-3. Locate the command entry for `uv` and replace it with the absolute path to the `uv` executable. This ensures that the correct version of `uv` is used when starting the server. On a mac, you can find this path using `which uv`.
+4. (Recommended) Locate the command entry for `uv` and replace it with the absolute path to the `uv` executable. This ensures that the correct version of `uv` is used when starting the server. You can find this path using `which uv` or `where.exe uv`.
 
-4. Restart Claude Desktop to apply the changes.
+5. Restart Claude Desktop to apply the changes. If you are using Windows, ensure Claude is stopped completely by closing the client using the system tray icon.
 
 ### Environment Variables
 
-The following environment variables are used to configure the Hydrolix connection:
+The following variables are used to configure the Hydrolix connection. These variables may be provided via the MCP config block (as shown above), a `.env` file, or traditional environment variables.
 
 #### Required Variables
 * `HYDROLIX_HOST`: The hostname of your Hydrolix server
@@ -77,12 +123,6 @@ The following environment variables are used to configure the Hydrolix connectio
 * `HYDROLIX_VERIFY`: Enable/disable SSL certificate verification
   - Default: `"true"`
   - Set to `"false"` to disable certificate verification (not recommended for production)
-* `HYDROLIX_CONNECT_TIMEOUT`: Connection timeout in seconds
-  - Default: `"30"`
-  - Increase this value if you experience connection timeouts
-* `HYDROLIX_SEND_RECEIVE_TIMEOUT`: Send/receive timeout in seconds
-  - Default: `"300"`
-  - Increase this value for long-running queries
 * `HYDROLIX_DATABASE`: Default database to use
   - Default: None (uses server default)
   - Set this to automatically connect to a specific database


### PR DESCRIPTION
Extends the README with:
- recommendations for effective querying
- removed TIMEOUT env vars (these were effectively ignored by the global 30s hard-coded timeout)
- more generalized documentation for configuration in different clients
- tips to resolve expected issues in Claude desktop setup
