### PR TITLE
Nit pick: Correct indentation for Claude config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ env:
   HYDROLIX_PASSWORD: <hydrolix-password>
 ```
 
-## Configuration Example (Claude Desktop)
+### Configuration Example (Claude Desktop)
 
 1. Open the Claude Desktop configuration file located at:
    - On macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`


### PR DESCRIPTION
I missed one layer of header [de]-emphasis