### PR TITLE
Alpic compatibility

### DIFF
--- a/mcp_hydrolix/main.py
+++ b/mcp_hydrolix/main.py
@@ -11,6 +11,7 @@ def main():
     if transport in http_transports:
         # Use the configured bind host (defaults to 127.0.0.1, can be set to 0.0.0.0)
         # and bind port (defaults to 8000)
+        # mcp.run(transport="http")
         mcp.run(transport=transport, host=config.mcp_bind_host, port=config.mcp_bind_port, stateless_http=True)
     else:
         # For stdio transport, no host or port is needed

--- a/mcp_hydrolix/main.py
+++ b/mcp_hydrolix/main.py
@@ -11,7 +11,7 @@ def main():
     if transport in http_transports:
         # Use the configured bind host (defaults to 127.0.0.1, can be set to 0.0.0.0)
         # and bind port (defaults to 8000)
-        mcp.run(transport=transport, host=config.mcp_bind_host, port=config.mcp_bind_port)
+        mcp.run(transport=transport, host=config.mcp_bind_host, port=config.mcp_bind_port, stateless_http=True)
     else:
         # For stdio transport, no host or port is needed
         mcp.run(transport=transport)


### PR DESCRIPTION
This PR adds 2 requirements to host the project on Alpic :

- Alpic enables statefulness at the gateway level, but hosted server can't be stateful themselves. The `stateless_http=True` option ensures the server is stateless
- Alpic relies on regex to source the transport used by a codebase. We're working on a more robust solution, but in the meantime the commented section helps match the regex and ensure http is used to communicate with the MCP server