### PR TITLE
Add per-request service account authentication via Bearer or query param

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,6 @@ HYDROLIX_HOST=my-cluster.hydrolix.net
 HYDROLIX_MCP_SERVER_TRANSPORT=http
 ```
 
-Though not part of the MCP specification, many MCP clients allow adding headers to MCP-issued requests. When this is possible, we recommend configuring the MCP client to pass a service account token via the `Authorization: Bearer <sa-token-here>` header instead of as a URL parameter for greater security.
+Though not part of the MCP specification, many MCP clients allow adding headers to MCP-issued requests. When this is possible, we recommend configuring the MCP client to pass a service account token via the `Authorization: Bearer <sa-token-here>` header instead of as a query parameter for greater security.
 
 Note: The bind host and port settings are only used when transport is set to "http" or "sse".

--- a/README.md
+++ b/README.md
@@ -218,7 +218,11 @@ At least one authentication method must be configured when using the stdio trans
 * `HYDROLIX_TOKEN`: Service account token for environment-based authentication
 * `HYDROLIX_USER` and `HYDROLIX_PASSWORD`: Username and password for environment-based authentication (both must be provided together)
 
-If no environment-based credentials are provided, per-request authentication must be used (available only with HTTP or SSE transport).
+In summary:
+- For stdio, you MUST use HYDROLIX_TOKEN or HYDROLIX_USER+HYDROLIX_PASS (environmental credentials)
+- For http/sse, you MAY use HYDROLIX_TOKEN or HYDROLIX_USER+HYDROLIX_PASS (environmental credentials), but you may instead use per-request credentials.
+
+If no credentials are provided via the environment or the request, the request will fail.
 
 #### Optional Variables
 * `HYDROLIX_PORT`: The port number of your Hydrolix server

--- a/mcp_hydrolix/auth/__init__.py
+++ b/mcp_hydrolix/auth/__init__.py
@@ -1,0 +1,26 @@
+"""Authentication package for MCP Hydrolix.
+
+This package contains authentication-related types used to define hydrolix auth
+in terms of FastMCP infrastructure
+"""
+from mcp_hydrolix.auth.credentials import (
+    HydrolixCredential,
+    ServiceAccountToken,
+    UsernamePassword,
+)
+from mcp_hydrolix.auth.mcp_providers import (
+    AccessToken,
+    ChainedAuthBackend,
+    GetParamAuthBackend,
+    HydrolixCredentialChain,
+)
+
+__all__ = [
+    "HydrolixCredential",
+    "ServiceAccountToken",
+    "UsernamePassword",
+    "AccessToken",
+    "ChainedAuthBackend",
+    "GetParamAuthBackend",
+    "HydrolixCredentialChain",
+]

--- a/mcp_hydrolix/auth/__init__.py
+++ b/mcp_hydrolix/auth/__init__.py
@@ -3,16 +3,18 @@
 This package contains authentication-related types used to define hydrolix auth
 in terms of FastMCP infrastructure
 """
-from mcp_hydrolix.auth.credentials import (
+
+from .credentials import (
     HydrolixCredential,
     ServiceAccountToken,
     UsernamePassword,
 )
-from mcp_hydrolix.auth.mcp_providers import (
+from .mcp_providers import (
     AccessToken,
     ChainedAuthBackend,
     GetParamAuthBackend,
     HydrolixCredentialChain,
+    TOKEN_PARAM,
 )
 
 __all__ = [
@@ -23,4 +25,5 @@ __all__ = [
     "ChainedAuthBackend",
     "GetParamAuthBackend",
     "HydrolixCredentialChain",
+    "TOKEN_PARAM",
 ]

--- a/mcp_hydrolix/auth/credentials.py
+++ b/mcp_hydrolix/auth/credentials.py
@@ -1,0 +1,63 @@
+"""Hydrolix credential types for authentication."""
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Optional
+import jwt
+
+
+class HydrolixCredential(ABC):
+    @abstractmethod
+    def clickhouse_config_entries(self) -> dict:
+        """
+        Returns the entries needed for a ClickHouse client config to use this credential.
+        This will typically add `access_token` or (`username` and `password`)
+        """
+        ...
+
+
+@dataclass
+class ServiceAccountToken(HydrolixCredential):
+    """Hydrolix credentials using a service account token."""
+
+    def __init__(self, token: str, expected_iss: Optional[str]):
+        """
+        Initialize a ServiceAccountToken from a token JWT (or raise an error if the claims are invalid).
+        NB the claims' signatures are NOT checked by this function -- these validations MUST NOT be considered
+        authoritative.
+        """
+
+        claims = jwt.decode(
+            token,
+            key="",  # NB service account signing key is not publicly-hosted, so we can't verify the signature
+            options={
+                "verify_signature": False,
+                "verify_iss": True,
+                "verify_iat": True,
+                "verify_exp": True,
+            },
+            issuer=expected_iss,
+        )
+        self.token = token
+        self.service_account_id = claims["sub"]
+        self.issued_at = claims["iss"]
+        self.expires_at = claims["exp"]
+
+    def clickhouse_config_entries(self) -> dict:
+        return {"access_token": self.token}
+
+    token: str
+    service_account_id: str
+    issued_at: int
+    expires_at: int
+
+
+@dataclass
+class UsernamePassword(HydrolixCredential):
+    """Hydrolix credentials using username and password."""
+
+    def clickhouse_config_entries(self) -> dict:
+        return {"username": self.username, "password": self.password}
+
+    username: str
+    password: str

--- a/mcp_hydrolix/auth/mcp_providers.py
+++ b/mcp_hydrolix/auth/mcp_providers.py
@@ -1,0 +1,133 @@
+"""Authentication backends and providers for MCP Hydrolix server."""
+
+from abc import abstractmethod
+import time
+from typing import List, ClassVar, Final, Optional
+
+from fastmcp.server.auth import AuthProvider, AccessToken as FastMCPAccessToken
+from mcp.server.auth.middleware.auth_context import (
+    AuthContextMiddleware as McpAuthContextMiddleware,
+)
+from mcp.server.auth.middleware.bearer_auth import (
+    AuthenticatedUser as McpAuthenticatedUser,
+    BearerAuthBackend,
+)
+from mcp.server.auth.provider import TokenVerifier as McpTokenVerifier
+from starlette.authentication import AuthenticationBackend, AuthCredentials
+from starlette.middleware import Middleware
+from starlette.middleware.authentication import AuthenticationMiddleware
+from starlette.requests import Request, HTTPConnection
+
+from mcp_hydrolix.auth.credentials import HydrolixCredential, ServiceAccountToken
+
+
+class ChainedAuthBackend(AuthenticationBackend):
+    """
+    Generic authentication backend that tries multiple backends in order. Returns the first successful
+    authentication result. Only tries an auth method once all previous auth methods have failed.
+    """
+
+    def __init__(self, backends: List[AuthenticationBackend]):
+        self.backends = backends
+
+    async def authenticate(self, conn: HTTPConnection):
+        # due to a very strange quirk of python syntax, this CANNOT be an anonymous async generator. The quirk is
+        # that async generator expressions aren't allowed to have `await` in their if conditions (though async
+        # generators have no such restriction on their if statements)
+        async def successful_results():
+            for backend in self.backends:
+                if (result := await backend.authenticate(conn)) is not None:
+                    yield result
+
+        return await anext(successful_results(), None)
+
+
+class GetParamAuthBackend(AuthenticationBackend):
+    """
+    Authentication backend that validates tokens from an HTTP GET parameter
+    """
+
+    def __init__(self, token_verifier: McpTokenVerifier, token_get_param: str):
+        self.token_verifier = token_verifier
+        self.token_get_param = token_get_param
+
+    async def authenticate(self, conn: HTTPConnection):
+        token = Request(conn.scope).query_params.get(self.token_get_param)
+
+        if token is None:
+            return None
+
+        # Validate the token with the verifier
+        auth_info = await self.token_verifier.verify_token(token)
+
+        if not auth_info:
+            return None
+
+        if auth_info.expires_at and auth_info.expires_at < int(time.time()):
+            return None
+
+        return AuthCredentials(auth_info.scopes), McpAuthenticatedUser(auth_info)
+
+
+class AccessToken(FastMCPAccessToken):
+    @abstractmethod
+    def as_credential(self) -> HydrolixCredential: ...
+
+
+class HydrolixCredentialChain(AuthProvider):
+    """
+    AuthProvider that authenticates with the following precedence:
+
+    - MCP-standard oAuth (not implemented!)
+    - Hydrolix service account via the "token" GET parameter
+    - Hydrolix service account via the Bearer token
+    """
+
+    class ServiceAccountAccess(AccessToken):
+        FAKE_CLIENT_ID: ClassVar[Final[str]] = "MCP_CLIENT_VIA_SERVICE_ACCOUNT"
+        FAKE_SCOPE: ClassVar[Final[str]] = "MCP_SERVICE_ACCOUNT_SCOPE"
+
+        expected_issuer: Optional[str] = None
+
+        def as_credential(self) -> ServiceAccountToken:
+            return ServiceAccountToken(self.token, self.expected_issuer)
+
+    def __init__(self, expected_issuer: Optional[str]):
+        """
+        Initialize HydrolixCredentialChain.
+
+        Args:
+            expected_issuer: The issuer URL that must be used (mitigates credential-stuffing)
+        """
+        super().__init__()
+        self.expected_issuer = expected_issuer
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        """
+        This is responsible for validating and authenticating the `token`.
+        See ChainedAuthBackend for how the token is obtained in the first place.
+        Authorization is performed by individual endpoints via `fastmcp.server.dependencies.get_access_token`
+        """
+        return HydrolixCredentialChain.ServiceAccountAccess(
+            token=token,
+            client_id=HydrolixCredentialChain.ServiceAccountAccess.FAKE_CLIENT_ID,
+            scopes=[HydrolixCredentialChain.ServiceAccountAccess.FAKE_SCOPE],
+            expires_at=None,
+            resource=None,
+            claims={},
+            expected_issuer=self.expected_issuer,
+        )
+
+    def get_middleware(self) -> list:
+        return [
+            Middleware(
+                AuthenticationMiddleware,
+                backend=ChainedAuthBackend(
+                    [
+                        BearerAuthBackend(self),
+                        GetParamAuthBackend(self, "token"),
+                    ]
+                ),
+            ),
+            Middleware(McpAuthContextMiddleware),
+        ]

--- a/mcp_hydrolix/auth/mcp_providers.py
+++ b/mcp_hydrolix/auth/mcp_providers.py
@@ -22,6 +22,7 @@ from .credentials import HydrolixCredential, ServiceAccountToken
 
 TOKEN_PARAM: Final[str] = "token"
 
+
 class ChainedAuthBackend(AuthenticationBackend):
     """
     Generic authentication backend that tries multiple backends in order. Returns the first successful

--- a/mcp_hydrolix/auth/mcp_providers.py
+++ b/mcp_hydrolix/auth/mcp_providers.py
@@ -46,7 +46,7 @@ class ChainedAuthBackend(AuthenticationBackend):
 
 class GetParamAuthBackend(AuthenticationBackend):
     """
-    Authentication backend that validates tokens from an HTTP GET parameter
+    Authentication backend that validates tokens from a query parameter
     """
 
     def __init__(self, token_verifier: McpTokenVerifier, token_get_param: str):

--- a/mcp_hydrolix/auth/mcp_providers.py
+++ b/mcp_hydrolix/auth/mcp_providers.py
@@ -78,11 +78,13 @@ class AccessToken(FastMCPAccessToken):
 
 class HydrolixCredentialChain(AuthProvider):
     """
-    AuthProvider that authenticates with the following precedence:
+    AuthProvider that authenticates with the following precedence (highest to lowest):
 
-    - MCP-standard oAuth (not implemented!)
-    - Hydrolix service account via the TOKEN_PARAM GET parameter
-    - Hydrolix service account via the Bearer token
+    1. Per-request Bearer token: Service account token via Authorization: Bearer <token> header
+    2. Per-request GET parameter: Service account token via ?token=<token> query parameter
+
+    NB MCP-standard oAuth is not currently implemented
+    NB all per-request credentials take precedence over all environment-variable-supplied credentials
     """
 
     class ServiceAccountAccess(AccessToken):

--- a/mcp_hydrolix/auth/mcp_providers.py
+++ b/mcp_hydrolix/auth/mcp_providers.py
@@ -18,8 +18,9 @@ from starlette.middleware import Middleware
 from starlette.middleware.authentication import AuthenticationMiddleware
 from starlette.requests import Request, HTTPConnection
 
-from mcp_hydrolix.auth.credentials import HydrolixCredential, ServiceAccountToken
+from .credentials import HydrolixCredential, ServiceAccountToken
 
+TOKEN_PARAM: Final[str] = "token"
 
 class ChainedAuthBackend(AuthenticationBackend):
     """
@@ -79,7 +80,7 @@ class HydrolixCredentialChain(AuthProvider):
     AuthProvider that authenticates with the following precedence:
 
     - MCP-standard oAuth (not implemented!)
-    - Hydrolix service account via the "token" GET parameter
+    - Hydrolix service account via the TOKEN_PARAM GET parameter
     - Hydrolix service account via the Bearer token
     """
 
@@ -125,7 +126,7 @@ class HydrolixCredentialChain(AuthProvider):
                 backend=ChainedAuthBackend(
                     [
                         BearerAuthBackend(self),
-                        GetParamAuthBackend(self, "token"),
+                        GetParamAuthBackend(self, TOKEN_PARAM),
                     ]
                 ),
             ),

--- a/mcp_hydrolix/logging_utils.py
+++ b/mcp_hydrolix/logging_utils.py
@@ -1,0 +1,49 @@
+"""Logging utilities for redacting sensitive information from logs."""
+
+import logging
+import re
+
+from .auth import TOKEN_PARAM
+
+
+class AccessLogTokenRedactingFilter(logging.Filter):
+    """
+    Filter that redacts token query parameters from uvicorn access logs.
+
+    This filter is specifically designed to intercept log messages that contain
+    request URLs with query parameters and replace token values with [REDACTED].
+    """
+
+    # Regex pattern to match token=<value> in query strings
+    # Matches: token=<anything except & or whitespace>
+    TOKEN_PATTERN = re.compile(rf"{TOKEN_PARAM}=[^&\s]+")
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        """
+        Filter method that redacts tokens from the log message.
+
+        Args:
+            record: The log record to filter
+
+        Returns:
+            True (side-effect only)
+        """
+        if hasattr(record, "msg") and isinstance(record.msg, str):
+            record.msg = self.TOKEN_PATTERN.sub(rf"{TOKEN_PARAM}=[REDACTED]", record.msg)
+
+        # Also check args if they exist (for formatted log messages)
+        if hasattr(record, "args") and record.args:
+            # Convert args to list for modification
+            if isinstance(record.args, tuple):
+                modified_args: list = []
+                for arg in record.args:
+                    if isinstance(arg, str):
+                        # Redact tokens from string arguments
+                        modified_args.append(
+                            self.TOKEN_PATTERN.sub(rf"{TOKEN_PARAM}=[REDACTED]", arg)
+                        )
+                    else:
+                        modified_args.append(arg)
+                record.args = tuple(modified_args)
+
+        return True

--- a/mcp_hydrolix/mcp_env.py
+++ b/mcp_hydrolix/mcp_env.py
@@ -50,7 +50,7 @@ class HydrolixConfig:
         HYDROLIX_MCP_BIND_PORT: Port to bind the MCP server to when using HTTP or SSE transport (default: 8000)
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize the configuration from environment variables."""
         self._validate_required_vars()
         # Credential to use for clickhouse connections when no per-request credential is provided
@@ -58,7 +58,7 @@ class HydrolixConfig:
 
         # Set the default credential to the service account from the environment, if available
         if (global_service_account := os.environ.get("HYDROLIX_TOKEN")) is not None:
-            self._default_credential = ServiceAccountToken(global_service_account)
+            self._default_credential = ServiceAccountToken(global_service_account, f"https://{self.host}/config")
         elif (global_username := os.environ.get("HYDROLIX_USER")) is not None and (
             global_password := os.environ.get("HYDROLIX_PASSWORD")
         ) is not None:
@@ -81,7 +81,7 @@ class HydrolixConfig:
 
     @property
     def host(self) -> str:
-        """Get the Hydrolix host."""
+        """Get the Hydrolix host. Called during __init__"""
         return os.environ["HYDROLIX_HOST"]
 
     @property
@@ -199,7 +199,7 @@ class HydrolixConfig:
         return config
 
     def _validate_required_vars(self) -> None:
-        """Validate that all required environment variables are set.
+        """Validate that all required environment variables are set. Called during __init__.
 
         Raises:
             ValueError: If any required environment variable is missing.

--- a/mcp_hydrolix/mcp_env.py
+++ b/mcp_hydrolix/mcp_env.py
@@ -9,7 +9,7 @@ import os
 from typing import Optional
 from enum import Enum
 
-from mcp_hydrolix.auth.credentials import HydrolixCredential, ServiceAccountToken, UsernamePassword
+from .auth.credentials import HydrolixCredential, ServiceAccountToken, UsernamePassword
 
 
 class TransportType(str, Enum):

--- a/mcp_hydrolix/mcp_env.py
+++ b/mcp_hydrolix/mcp_env.py
@@ -58,7 +58,9 @@ class HydrolixConfig:
 
         # Set the default credential to the service account from the environment, if available
         if (global_service_account := os.environ.get("HYDROLIX_TOKEN")) is not None:
-            self._default_credential = ServiceAccountToken(global_service_account, f"https://{self.host}/config")
+            self._default_credential = ServiceAccountToken(
+                global_service_account, f"https://{self.host}/config"
+            )
         elif (global_username := os.environ.get("HYDROLIX_USER")) is not None and (
             global_password := os.environ.get("HYDROLIX_PASSWORD")
         ) is not None:

--- a/mcp_hydrolix/mcp_env.py
+++ b/mcp_hydrolix/mcp_env.py
@@ -52,12 +52,10 @@ class ServiceAccountToken(HydrolixCredential):
                             options={
                                 "verify_signature": False,
                                 "verify_iss": True,
-                                "verify_aud": True,
                                 "verify_iat": True,
                                 "verify_exp": True,
                             },
-                            issuer="config-api",
-                            audience="hydrolix",
+                            issuer=f"https://{get_config().host}/config",
                             )
         self.token = token
         self.service_account_id = claims["sub"]
@@ -128,7 +126,7 @@ class HydrolixConfig:
             # from the environment, if available
             self._default_credential = UsernamePassword(global_username, global_password)
 
-    def creds_with(self, request_credential: Optional[HydrolixCredential] = None) -> HydrolixCredential:
+    def creds_with(self, request_credential: Optional[HydrolixCredential]) -> HydrolixCredential:
         if request_credential is not None:
             return request_credential
         elif self._default_credential is not None:
@@ -223,7 +221,7 @@ class HydrolixConfig:
         """
         return int(os.getenv("HYDROLIX_MCP_BIND_PORT", "8000"))
 
-    def get_client_config(self, request_credential: Optional[HydrolixCredential] = None) -> dict:
+    def get_client_config(self, request_credential: Optional[HydrolixCredential]) -> dict:
         """
         Get the configuration dictionary for clickhouse_connect client.
 

--- a/mcp_hydrolix/mcp_env.py
+++ b/mcp_hydrolix/mcp_env.py
@@ -215,7 +215,7 @@ class HydrolixConfig:
         # HYDROLIX_USER and HYDROLIX_PASSWORD must either be both present or both absent
         if ("HYDROLIX_USER" in os.environ) != ("HYDROLIX_PASSWORD" in os.environ):
             raise ValueError(
-                "User/password authentication is only partially configured: pass both HYDROLIX_USER and HYDROLIX_PASSWORD"
+                "User/password authentication is only partially configured: set both HYDROLIX_USER and HYDROLIX_PASSWORD"
             )
 
         if missing_vars:

--- a/mcp_hydrolix/mcp_server.py
+++ b/mcp_hydrolix/mcp_server.py
@@ -141,8 +141,8 @@ class HydrolixCredentialChain(AuthProvider):
         FAKE_CLIENT_ID: ClassVar[Final[str]] = "MCP_CLIENT_VIA_SERVICE_ACCOUNT"
         FAKE_SCOPE: ClassVar[Final[str]] = "MCP_SERVICE_ACCOUNT_SCOPE"
 
-        def as_credential(self):
-            ServiceAccountToken(self.token)
+        def as_credential(self) -> ServiceAccountToken:
+            return ServiceAccountToken(self.token)
 
     def __init__(self, connection_settings: HydrolixConfig):
         super().__init__()
@@ -367,17 +367,15 @@ def create_hydrolix_client(request_credential: Optional[HydrolixCredential]):
     """
     client_config = get_config()
     creds = client_config.creds_with(request_credential)
-    logger.error(creds)
     auth_info = (
         f"as {creds.username}" if isinstance(creds, UsernamePassword)
         else f"using service account {creds.service_account_id}"
     )
     logger.info(
-        f"Creating Hydrolix client connection to {client_config['host']}:{client_config['port']} "
+        f"Creating Hydrolix client connection to {client_config.host}:{client_config.port} "
         f"{auth_info} "
-        f"(secure={client_config['secure']}, verify={client_config['verify']}, "
-        f"connect_timeout={client_config['connect_timeout']}s, "
-        f"send_receive_timeout={client_config['send_receive_timeout']}s)"
+        f"(connect_timeout={client_config.connect_timeout}s, "
+        f"send_receive_timeout={client_config.send_receive_timeout}s)"
     )
 
     try:

--- a/mcp_hydrolix/mcp_server.py
+++ b/mcp_hydrolix/mcp_server.py
@@ -15,14 +15,15 @@ from fastmcp.server.dependencies import get_access_token
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse
 
-from mcp_hydrolix.auth.credentials import ServiceAccountToken
-from mcp_hydrolix.mcp_env import HydrolixConfig, get_config
-from mcp_hydrolix.auth import (
+from .mcp_env import HydrolixConfig, get_config
+from .auth import (
     HydrolixCredential,
     UsernamePassword,
     AccessToken,
     HydrolixCredentialChain,
+    ServiceAccountToken,
 )
+from .logging_utils import AccessLogTokenRedactingFilter
 
 
 @dataclass
@@ -64,6 +65,10 @@ logging.basicConfig(
     level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 )
 logger = logging.getLogger(MCP_SERVER_NAME)
+
+# Add token redaction filter to uvicorn access logs
+uvicorn_access_logger = logging.getLogger("uvicorn.access")
+uvicorn_access_logger.addFilter(AccessLogTokenRedactingFilter())
 
 QUERY_EXECUTOR = concurrent.futures.ThreadPoolExecutor(max_workers=10)
 atexit.register(lambda: QUERY_EXECUTOR.shutdown(wait=True))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
      "python-dotenv>=1.0.1",
      "clickhouse-connect>=0.8.16",
      "pip-system-certs>=4.0",
+     "pyjwt>=2.10.1",
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -537,6 +537,7 @@ dependencies = [
     { name = "clickhouse-connect" },
     { name = "fastmcp" },
     { name = "pip-system-certs" },
+    { name = "pyjwt" },
     { name = "python-dotenv" },
 ]
 
@@ -554,6 +555,7 @@ requires-dist = [
     { name = "fastmcp", specifier = ">=2.0.0" },
     { name = "pip-system-certs", specifier = ">=4.0" },
     { name = "pre-commit", marker = "extra == 'dev'" },
+    { name = "pyjwt", specifier = ">=2.10.1" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-asyncio", marker = "extra == 'dev'" },
     { name = "python-dotenv", specifier = ">=1.0.1" },
@@ -809,6 +811,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.10.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/46/bd74733ff231675599650d3e47f361794b22ef3e3770998dda30d3b63726/pyjwt-2.10.1.tar.gz", hash = "sha256:3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953", size = 87785, upload-time = "2024-11-28T03:43:29.933Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/61/ad/689f02752eeec26aed679477e80e632ef1b682313be70793d798c1d5fc8f/PyJWT-2.10.1-py3-none-any.whl", hash = "sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb", size = 22997, upload-time = "2024-11-28T03:43:27.893Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -531,7 +531,7 @@ wheels = [
 
 [[package]]
 name = "mcp-hydrolix"
-version = "0.1.4"
+version = "0.1.5"
 source = { editable = "." }
 dependencies = [
     { name = "clickhouse-connect" },


### PR DESCRIPTION
Adds support for per-request service account authentication in the MCP Hydrolix server. Authenticates Hydrolix service account tokens via Bearer auth or the `token` query parameter, in addition to the existing environment-based credentials.

## Implementation Notes

This implementation is designed to be forward-looking, to enable easy addition of standard oAuth later.

- Created new `auth/` package with credential types (`ServiceAccountToken`, `UsernamePassword`) and authentication backends, and a `ChainedAuthBackend` that tries multiple auth methods in order: Bearer token → GET parameter token
- Refactored `HydrolixConfig` to support per-request credentials via `creds_with()` method
- Basic claims are validated for service accounts, but this should be treated as an optimization rather than a rigorous security measure. The token will be properly validated by the cluster when the query is received at the query-head.
- GET parameter tokens are redacted from access logs via a `AccessLogTokenRedactingFilter`

This PR also makes incremental progress towards type-safety