### PR TITLE
[IL] [MCP] [HDX-10389] Fix SSL verification when HYDROLIX_VERIFY is false

### DIFF
--- a/mcp_hydrolix/mcp_server.py
+++ b/mcp_hydrolix/mcp_server.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import signal
-import sys
 from collections.abc import Sequence
 from dataclasses import asdict, is_dataclass
 from typing import Any, Final, Optional, List, cast, TypedDict
@@ -140,8 +139,10 @@ pool_kwargs = {
 }
 if not HYDROLIX_CONFIG.verify:
     import urllib3
+
     urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 client_shared_pool = httputil.get_pool_manager(**pool_kwargs)
+
 
 def term(*args, **kwargs):
     client_shared_pool.clear()


### PR DESCRIPTION
What does this MR do?
-----------------------

  ## Problem
  When `HYDROLIX_VERIFY` config is set to `false`, SSL verification was not being properly disabled for the ClickHouse connection pool, causing connection failures to Hydrolix clusters with self-signed certificates.

  ## Changes
  - Pass `verify` parameter to HTTP pool manager based on config
  - Disable SSL warnings when verification is disabled
  - Fixes connection issues in dev/test environments with self-signed certs

Does this MR meet the acceptance criteria?
--------------------------------------------

* [ ] Documentation created/updated
* [ ] Tests added for this feature/bug
* [ ] Does this change request have any security impacts?

Release Notes
---------------------------------------------------

* Major changes:
    *
* Minor changes:
    *
* Bugfixes:
    *
* Issues Closed:
    *
* Security impacts identified:
    *

Testing
--------------------------------------------
