### PR TITLE
[IL] [MCP] [HDX-10389] Fix SSL certificate verification with certifi CA bundle

### DIFF
--- a/mcp_hydrolix/mcp_server.py
+++ b/mcp_hydrolix/mcp_server.py
@@ -137,10 +137,16 @@ pool_kwargs = {
     "num_pools": 1,
     "verify": HYDROLIX_CONFIG.verify,
 }
-if not HYDROLIX_CONFIG.verify:
+
+# When verify=True, use certifi CA bundle for SSL verification
+# This ensures we trust modern CAs like Let's Encrypt
+if HYDROLIX_CONFIG.verify:
+    pool_kwargs["ca_cert"] = "certifi"
+else:
     import urllib3
 
     urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
 client_shared_pool = httputil.get_pool_manager(**pool_kwargs)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
      "python-dotenv>=1.1,<1.2",
      "clickhouse-connect>=0.10,<0.11",
      "pip-system-certs>=4.0,<5.0",
+     "certifi>=2024.0.0",
      "gunicorn>=23.0,<24.0",
      "pyjwt>=2.10,<2.11",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
      "python-dotenv>=1.1,<1.2",
      "clickhouse-connect>=0.10,<0.11",
      "pip-system-certs>=4.0,<5.0",
-     "certifi>=2024.0.0",
+     "certifi>=2026.1.4",
      "gunicorn>=23.0,<24.0",
      "pyjwt>=2.10,<2.11",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -77,11 +77,11 @@ wheels = [
 
 [[package]]
 name = "certifi"
-version = "2025.11.12"
+version = "2026.1.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/8c/58f469717fa48465e4a50c014a0400602d3c437d7c0c468e17ada824da3a/certifi-2025.11.12.tar.gz", hash = "sha256:d8ab5478f2ecd78af242878415affce761ca6bc54a22a27e026d7c25357c3316", size = 160538, upload-time = "2025-11-12T02:54:51.517Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/2d/a891ca51311197f6ad14a7ef42e2399f36cf2f9bd44752b3dc4eab60fdc5/certifi-2026.1.4.tar.gz", hash = "sha256:ac726dd470482006e014ad384921ed6438c457018f4b3d204aea4281258b2120", size = 154268, upload-time = "2026-01-04T02:42:41.825Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/7d/9bc192684cea499815ff478dfcdc13835ddf401365057044fb721ec6bddb/certifi-2025.11.12-py3-none-any.whl", hash = "sha256:97de8790030bbd5c2d96b7ec782fc2f7820ef8dba6db909ccf95449f2d062d4b", size = 159438, upload-time = "2025-11-12T02:54:49.735Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/ad/3cc14f097111b4de0040c83a525973216457bbeeb63739ef1ed275c1c021/certifi-2026.1.4-py3-none-any.whl", hash = "sha256:9943707519e4add1115f44c2bc244f782c0249876bf51b6599fee1ffbedd685c", size = 152900, upload-time = "2026-01-04T02:42:40.15Z" },
 ]
 
 [[package]]
@@ -826,7 +826,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "certifi", specifier = ">=2024.0.0" },
+    { name = "certifi", specifier = ">=2026.1.4" },
     { name = "clickhouse-connect", specifier = ">=0.10,<0.11" },
     { name = "fastapi", marker = "extra == 'dev'", specifier = ">=0.124" },
     { name = "fastmcp", specifier = ">=2.14,<2.15" },

--- a/uv.lock
+++ b/uv.lock
@@ -803,6 +803,7 @@ name = "mcp-hydrolix"
 version = "0.1.7"
 source = { editable = "." }
 dependencies = [
+    { name = "certifi" },
     { name = "clickhouse-connect" },
     { name = "fastmcp" },
     { name = "gunicorn" },
@@ -825,6 +826,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "certifi", specifier = ">=2024.0.0" },
     { name = "clickhouse-connect", specifier = ">=0.10,<0.11" },
     { name = "fastapi", marker = "extra == 'dev'", specifier = ">=0.124" },
     { name = "fastmcp", specifier = ">=2.14,<2.15" },


### PR DESCRIPTION
What does this MR do?
-----------------------

Fix SSL certificate verification when `HYDROLIX_VERIFY=true` by using the certifi CA bundle for validating server certificates.

  ## Problem

  When `HYDROLIX_VERIFY=true` was set, SSL connections failed with:
  SSLCertVerificationError: certificate verify failed: unable to get local issuer certificate

  **Root Cause:**
  The connection pool was created with `verify=True` but no CA certificate bundle was provided. Without a CA bundle, Python cannot verify any SSL certificates, even valid ones from public CAs like Let's Encrypt.

  ## Solution

  Configure the connection pool to use certifi's Mozilla CA bundle when SSL verification is enabled.

  **Key Change:**
  ```python
  if HYDROLIX_CONFIG.verify:
      pool_kwargs["ca_cert"] = "certifi"  # Use Mozilla CA bundle

  The string "certifi" is a special value recognized by clickhouse-connect that tells it to use the certifi package's CA bundle internally.

  What is certifi?

  certifi is a Python package providing Mozilla's curated collection of Root Certificates used by Firefox. It includes:
  - All major public Certificate Authorities
  - Let's Encrypt (used by many Hydrolix servers)
  - Regular updates with new/revoked certificates


Does this MR meet the acceptance criteria?
--------------------------------------------

* [ ] Documentation created/updated
* [ ] Tests added for this feature/bug
* [ ] Does this change request have any security impacts?

Release Notes
---------------------------------------------------

* Major changes:
    *
* Minor changes:
    *
* Bugfixes:
    *
* Issues Closed:
    *
* Security impacts identified:
    *

Testing
--------------------------------------------
