### PR TITLE
[IL] [MCP] [HDX-10474] Disable JWT issuer validation for environment-based service account tokens

### DIFF
--- a/mcp_hydrolix/mcp_env.py
+++ b/mcp_hydrolix/mcp_env.py
@@ -64,9 +64,7 @@ class HydrolixConfig:
         self._default_credential: Optional[HydrolixCredential] = None
 
         # Set the default credential to the service account from the environment, if available
-        if (
-            global_service_account := os.environ.get("HYDROLIX_TOKEN")
-        ) and global_service_account.strip():
+        if global_service_account := (os.environ.get("HYDROLIX_TOKEN") or "").strip():
             self._default_credential = ServiceAccountToken(global_service_account, None)
         elif (global_username := os.environ.get("HYDROLIX_USER")) is not None and (
             global_password := os.environ.get("HYDROLIX_PASSWORD")

--- a/mcp_hydrolix/mcp_env.py
+++ b/mcp_hydrolix/mcp_env.py
@@ -64,10 +64,10 @@ class HydrolixConfig:
         self._default_credential: Optional[HydrolixCredential] = None
 
         # Set the default credential to the service account from the environment, if available
-        if (global_service_account := os.environ.get("HYDROLIX_TOKEN")) is not None:
-            self._default_credential = ServiceAccountToken(
-                global_service_account, f"https://{self.host}/config"
-            )
+        if (
+            global_service_account := os.environ.get("HYDROLIX_TOKEN")
+        ) and global_service_account.strip():
+            self._default_credential = ServiceAccountToken(global_service_account, None)
         elif (global_username := os.environ.get("HYDROLIX_USER")) is not None and (
             global_password := os.environ.get("HYDROLIX_PASSWORD")
         ) is not None:


### PR DESCRIPTION
## What does this PR do?

Fixes `InvalidIssuerError` crashes when `HYDROLIX_TOKEN` environment variable is set.

## Problem

The MCP server crashes with `jwt.exceptions.InvalidIssuerError` because JWT issuer validation expects `https://{HYDROLIX_HOST}/config` but tokens have different issuer URLs (e.g., `https://hdx-lab-innovations.hydrolix.dev/config`).

## Solution

1. **Disable issuer validation** - Pass `None` to `ServiceAccountToken` instead of expected issuer URL
2. **Fix token handling** - Use `(os.environ.get("HYDROLIX_TOKEN") or "").strip()` to properly handle `None`, empty strings, and whitespace

## Changes

```python
# Before
if (global_service_account := os.environ.get("HYDROLIX_TOKEN")) is not None:
    self._default_credential = ServiceAccountToken(
        global_service_account, f"https://{self.host}/config"
    )

# After
if global_service_account := (os.environ.get("HYDROLIX_TOKEN") or "").strip():
    self._default_credential = ServiceAccountToken(global_service_account, None)
```

## Why This Is Safe

- Mirrors existing behavior for per-request tokens (commit 8890f1c)
- Tokens come from trusted environment variables (K8s secrets)
- JWT signature validation is already disabled (signing key unavailable)
- Issuer validation provided minimal security value given the deployment model

## Testing

### Local Testing
- ✅ Local testing with mismatched issuer - server starts successfully
- ✅ Health check passes
- ✅ MCP tools work correctly

### Docker Image
- ✅ Docker image built and pushed: `us-docker.pkg.dev/hdx-art/t/mcp-hydrolix:latest-fix`

### Cluster Testing (hdx-lab-innovations)

**1. Per-request Authentication (Bearer token in Authorization header)**
- ✅ Deployed to `hdx-lab-innovations` cluster
- ✅ MCP tools accessible via `https://hdx-lab-innovations.hydrolix.dev/mcp`
- ✅ Per-request authentication working as expected

**2. Environment-based Authentication (K8s secret)**
- Created K8s secret with `HYDROLIX_TOKEN`:
  ```bash
  kubectl create secret generic mcp-hydrolix --from-literal=HYDROLIX_TOKEN="<token>"
  ```
- Restarted MCP deployment to pick up secret
- Tested from within cluster without per-request token:
  ```bash
  kubectl run curl-test --image=curlimages/curl:latest --rm -i --restart=Never -- \
    curl -s http://mcp-hydrolix:8000/health
  
  # Result: OK - Connected to Hydrolix compatible with ClickHouse 24.8.6.1
  ```
- ✅ **Environment token authentication working** - MCP server successfully authenticates to Hydrolix using `HYDROLIX_TOKEN` from K8s secret

Fixes HDX-10474