### PR TITLE
[IL][HDX-10458] Registering SIGQUIT only if supported

### DIFF
--- a/mcp_hydrolix/mcp_server.py
+++ b/mcp_hydrolix/mcp_server.py
@@ -2,7 +2,7 @@ import logging
 import re
 import signal
 from collections.abc import Sequence
-from typing import Any, Final, Optional, List, cast, TypedDict
+from typing import Any, Final, List, Optional, TypedDict, cast
 
 import clickhouse_connect
 from clickhouse_connect import common
@@ -167,7 +167,8 @@ def term(*args, **kwargs):
 
 signal.signal(signal.SIGTERM, term)
 signal.signal(signal.SIGINT, term)
-signal.signal(signal.SIGQUIT, term)
+if hasattr(signal, "SIGQUIT"):
+    signal.signal(signal.SIGQUIT, term)
 
 
 async def execute_query(query: str) -> HdxQueryResult:


### PR DESCRIPTION
What does this MR do?
-----------------------
SIGQUIT is a POSIX specific signal that is not supported by Windows. Running the MCP server on Windows errors out because `signal` is missing the `SIGQUIT` attribute on Windows. This PR fixes this bug by checking if SIGQUIT is defined before registering the signal.

Does this MR meet the acceptance criteria?
--------------------------------------------

* [ ] Documentation created/updated
* [ ] Tests added for this feature/bug
* [ ] Does this change request have any security impacts?

Release Notes
---------------------------------------------------

* Major changes:
    *
* Minor changes:
    *
* Bugfixes:
    * Check if SIGQUIT is defined before registering hook
* Issues Closed:
    *
* Security impacts identified:
    *

Testing
--------------------------------------------
Run the MCP server on Windows and check that an error such as `AttributeError: module 'signal' has no attribute 'SIGQUIT'` isn't logged.