### PR TITLE
[HDX-10818] Return run_select_query results in TOON encoding

### DIFF
--- a/mcp_hydrolix/mcp_server.py
+++ b/mcp_hydrolix/mcp_server.py
@@ -1,7 +1,6 @@
 import logging
 import re
 import signal
-from collections.abc import Sequence
 from typing import Any, Final, List, Optional, TypedDict, cast
 
 import clickhouse_connect
@@ -11,6 +10,7 @@ from clickhouse_connect.driver.binding import format_query_value
 from dotenv import load_dotenv
 from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
+from fastmcp.tools.tool import ToolResult
 from fastmcp.server.dependencies import get_access_token
 from jwt import DecodeError
 from pydantic import Field
@@ -558,7 +558,7 @@ async def list_tables(
 
 @mcp.tool()
 @with_serializer
-async def run_select_query(query: str) -> dict[str, tuple | Sequence[str | Sequence[Any]]]:
+async def run_select_query(query: str) -> ToolResult:
     """Run a SELECT query in a Hydrolix time-series database using the Clickhouse SQL dialect.
     Queries run using this tool will timeout after 30 seconds.
 

--- a/mcp_hydrolix/utils.py
+++ b/mcp_hydrolix/utils.py
@@ -1,66 +1,76 @@
 import inspect
 import ipaddress
 import json
-from datetime import datetime, time, date
+import logging
+from datetime import date, datetime, time
 from decimal import Decimal
 from functools import wraps
 
 import fastmcp.utilities.types
 from fastmcp.tools.tool import ToolResult
+from toon_format import encode as toon_encode
+
+logger = logging.getLogger(__name__)
 
 
 class ExtendedEncoder(json.JSONEncoder):
     """Extends JSONEncoder to apply custom serialization of CH data types."""
 
     def default(self, obj):
-        if isinstance(obj, ipaddress.IPv4Address):
+        if isinstance(obj, (ipaddress.IPv4Address, ipaddress.IPv6Address)):
             return str(obj)
         if isinstance(obj, datetime):
             return obj.timestamp()
         if isinstance(obj, (date, time)):
             return obj.isoformat()
         if isinstance(obj, bytes):
-            return obj.decode()
+            return obj.decode("utf-8", errors="replace")
         if isinstance(obj, Decimal):
             return str(obj)
         return super().default(obj)
 
 
+def _serialize_query_result(result: dict) -> tuple[str, dict]:
+    """
+    Serialize a HdxQueryResult to TOON format for LLM consumption.
+
+    Normalizes CH-specific types (datetime, Decimal, IPv4/6Address, bytes) via
+    ExtendedEncoder, converts the columnar structure to a list of records, then
+    encodes as TOON. Falls back to JSON if TOON encoding fails.
+
+    :returns: (encoded_string, structured_dict) tuple
+    """
+    normalized: dict = json.loads(json.dumps(result, cls=ExtendedEncoder))
+
+    records = [dict(zip(normalized["columns"], row)) for row in normalized["rows"]]
+    try:
+        return toon_encode(records), normalized
+    except Exception as exc:
+        logger.warning("TOON encoding failed, falling back to JSON: %s", exc)
+        return json.dumps(records), normalized
+
+
 def with_serializer(fn):
     """
-    Decorator to apply custom serialization to CH query tool result.
-    Should be applied as a first decorator of the tool function.
+    Decorator to serialize HdxQueryResult to TOON for LLM consumption.
+
+    Must be the innermost decorator (directly above the function definition,
+    below @mcp.tool()).
 
     :returns: sync/async wrapper of mcp tool function
     """
 
     @wraps(fn)
     def wrapper(*args, **kwargs):
-        """
-        Sync wrapper of mcpt tool `fn` function.
-        Function should return a dict or None.
-
-        :returns: ToolResult object with text-serialized and structured content.
-        """
         result = fn(*args, **kwargs)
-        if not isinstance(result, dict):
-            result = {"result": result}
-        enc = json.dumps(result, cls=ExtendedEncoder)
-        return ToolResult(content=enc, structured_content=json.loads(enc))
+        toon_str, structured = _serialize_query_result(result)
+        return ToolResult(content=toon_str, structured_content=structured)
 
     @wraps(fn)
     async def async_wrapper(*args, **kwargs):
-        """
-        Async wrapper of mcp tool `fn` function.
-        Function should return a dict or None.
-
-        :returns: ToolResult object with text-serialized and structured content.
-        """
         result = await fn(*args, **kwargs)
-        if not isinstance(result, dict):
-            result = {"result": result}
-        enc = json.dumps(result, cls=ExtendedEncoder)
-        return ToolResult(content=enc, structured_content=json.loads(enc))
+        toon_str, structured = _serialize_query_result(result)
+        return ToolResult(content=toon_str, structured_content=structured)
 
     # TODO: remove next signature fix code when a new fastmcp released (https://github.com/jlowin/fastmcp/issues/2524)
     new_fn = fastmcp.utilities.types.create_function_without_params(fn, ["ctx"])

--- a/mcp_hydrolix/utils.py
+++ b/mcp_hydrolix/utils.py
@@ -5,6 +5,7 @@ import logging
 from datetime import date, datetime, time
 from decimal import Decimal
 from functools import wraps
+from typing import Any
 
 import fastmcp.utilities.types
 from fastmcp.tools.tool import ToolResult
@@ -30,24 +31,40 @@ class ExtendedEncoder(json.JSONEncoder):
         return super().default(obj)
 
 
+def _normalize_value(val: Any) -> Any:
+    """Convert a CH-specific type to a TOON/JSON-safe primitive."""
+    if isinstance(val, (ipaddress.IPv4Address, ipaddress.IPv6Address)):
+        return str(val)
+    if isinstance(val, datetime):
+        return val.timestamp()
+    if isinstance(val, (date, time)):
+        return val.isoformat()
+    if isinstance(val, bytes):
+        return val.decode("utf-8", errors="replace")
+    if isinstance(val, Decimal):
+        return str(val)
+    return val
+
+
 def _serialize_query_result(result: dict) -> tuple[str, dict]:
     """
     Serialize a HdxQueryResult to TOON format for LLM consumption.
 
-    Normalizes CH-specific types (datetime, Decimal, IPv4/6Address, bytes) via
-    ExtendedEncoder, converts the columnar structure to a list of records, then
-    encodes as TOON. Falls back to JSON if TOON encoding fails.
+    Normalizes CH-specific types (datetime, Decimal, IPv4/6Address, bytes) directly,
+    converts the columnar structure to a list of records, then encodes as TOON.
+    Falls back to JSON if TOON encoding fails.
 
     :returns: (encoded_string, structured_dict) tuple
     """
-    normalized: dict = json.loads(json.dumps(result, cls=ExtendedEncoder))
-
-    records = [dict(zip(normalized["columns"], row)) for row in normalized["rows"]]
+    columns = result["columns"]
+    normalized_rows = [[_normalize_value(v) for v in row] for row in result["rows"]]
+    records = [dict(zip(columns, row)) for row in normalized_rows]
+    structured = {"columns": columns, "rows": normalized_rows}
     try:
-        return toon_encode(records), normalized
+        return toon_encode(records), structured
     except Exception as exc:
         logger.warning("TOON encoding failed, falling back to JSON: %s", exc)
-        return json.dumps(records), normalized
+        return json.dumps(records), structured
 
 
 def with_serializer(fn):

--- a/mcp_hydrolix/utils.py
+++ b/mcp_hydrolix/utils.py
@@ -1,3 +1,4 @@
+import base64
 import inspect
 import ipaddress
 import json
@@ -23,7 +24,7 @@ def _normalize_value(val: Any) -> Any:
     if isinstance(val, (date, time)):
         return val.isoformat()
     if isinstance(val, bytes):
-        return val.decode("utf-8", errors="replace")
+        return base64.b64encode(val).decode("ascii")
     if isinstance(val, Decimal):
         return str(val)
     return val

--- a/mcp_hydrolix/utils.py
+++ b/mcp_hydrolix/utils.py
@@ -14,23 +14,6 @@ from toon_format import encode as toon_encode
 logger = logging.getLogger(__name__)
 
 
-class ExtendedEncoder(json.JSONEncoder):
-    """Extends JSONEncoder to apply custom serialization of CH data types."""
-
-    def default(self, obj):
-        if isinstance(obj, (ipaddress.IPv4Address, ipaddress.IPv6Address)):
-            return str(obj)
-        if isinstance(obj, datetime):
-            return obj.timestamp()
-        if isinstance(obj, (date, time)):
-            return obj.isoformat()
-        if isinstance(obj, bytes):
-            return obj.decode("utf-8", errors="replace")
-        if isinstance(obj, Decimal):
-            return str(obj)
-        return super().default(obj)
-
-
 def _normalize_value(val: Any) -> Any:
     """Convert a CH-specific type to a TOON/JSON-safe primitive."""
     if isinstance(val, (ipaddress.IPv4Address, ipaddress.IPv6Address)):
@@ -57,9 +40,8 @@ def _serialize_query_result(result: dict) -> tuple[str, dict]:
     :returns: (encoded_string, structured_dict) tuple
     """
     columns = result["columns"]
-    normalized_rows = [[_normalize_value(v) for v in row] for row in result["rows"]]
-    records = [dict(zip(columns, row)) for row in normalized_rows]
-    structured = {"columns": columns, "rows": normalized_rows}
+    records = [dict(zip(columns, (_normalize_value(v) for v in row))) for row in result["rows"]]
+    structured = {"columns": columns, "rows": [list(record.values()) for record in records]}
     try:
         return toon_encode(records), structured
     except Exception as exc:

--- a/mcp_hydrolix/utils.py
+++ b/mcp_hydrolix/utils.py
@@ -41,8 +41,13 @@ def _serialize_query_result(result: dict[str, Any]) -> tuple[str, dict[str, Any]
     :returns: (encoded_string, structured_dict) tuple
     """
     columns = result["columns"]
-    records = [dict(zip(columns, (_normalize_value(v) for v in row))) for row in result["rows"]]
-    structured = {"columns": columns, "rows": [list(record.values()) for record in records]}
+    records = [
+        {col: _normalize_value(val) for col, val in zip(columns, row)} for row in result["rows"]
+    ]
+    structured = {
+        "columns": columns,
+        "rows": [list(record.values()) for record in records],
+    }
     try:
         return toon_encode(records), structured
     except Exception as exc:

--- a/mcp_hydrolix/utils.py
+++ b/mcp_hydrolix/utils.py
@@ -30,7 +30,7 @@ def _normalize_value(val: Any) -> Any:
     return val
 
 
-def _serialize_query_result(result: dict) -> tuple[str, dict]:
+def _serialize_query_result(result: dict[str, Any]) -> tuple[str, dict[str, Any]]:
     """
     Serialize a HdxQueryResult to TOON format for LLM consumption.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
      "certifi>=2026.1.4",
      "gunicorn>=23.0,<24.0",
      "pyjwt>=2.10,<2.11",
-     "toon-format",
+     "toon-format>=0.9.0b1",
 ]
 
 [project.scripts]
@@ -40,9 +40,6 @@ packages = ["mcp_hydrolix"]
 
 [tool.ruff]
 line-length = 100
-
-[tool.uv.sources]
-toon-format = { git = "https://github.com/toon-format/toon-python.git" }
 
 [build-system]
 requires = ["hatchling"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
      "certifi>=2026.1.4",
      "gunicorn>=23.0,<24.0",
      "pyjwt>=2.10,<2.11",
+     "toon-format",
 ]
 
 [project.scripts]
@@ -39,6 +40,9 @@ packages = ["mcp_hydrolix"]
 
 [tool.ruff]
 line-length = 100
+
+[tool.uv.sources]
+toon-format = { git = "https://github.com/toon-format/toon-python.git" }
 
 [build-system]
 requires = ["hatchling"]

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,5 +1,4 @@
 import asyncio
-import json
 import os
 import time
 import uuid
@@ -437,7 +436,7 @@ async def test_concurrent_queries(monkeypatch, mcp_server, setup_test_database):
     # Check each result
     assert results.done()
     for result in results.result():
-        query_result = json.loads(result.content[0].text)
+        query_result = result.structured_content
         assert "rows" in query_result
         assert len(query_result["rows"]) == 1
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,8 +4,6 @@ import pytest
 from datetime import datetime, time
 from decimal import Decimal
 
-from mcp.types import TextContent
-
 from mcp_hydrolix.utils import ExtendedEncoder, with_serializer
 from fastmcp.tools.tool import ToolResult
 
@@ -101,6 +99,19 @@ class TestExtendedEncoder:
         assert parsed["users"][1]["ip"] == "192.168.1.101"
         assert parsed["users"][1]["balance"] == "2000.75"
 
+    def test_ipv6_address_serialization(self):
+        """Test that IPv6 addresses are serialized to strings."""
+        ip = ipaddress.IPv6Address("2001:db8::1")
+        result = json.dumps({"ip": ip}, cls=ExtendedEncoder)
+        assert result == '{"ip": "2001:db8::1"}'
+
+    def test_bytes_non_utf8_serialization(self):
+        """Non-UTF-8 bytes are decoded with replacement rather than raising."""
+        data = b"\xff\xfe"  # invalid UTF-8
+        result = json.dumps({"data": data}, cls=ExtendedEncoder)
+        parsed = json.loads(result)
+        assert isinstance(parsed["data"], str)  # did not raise
+
     def test_standard_types_unchanged(self):
         """Test that standard JSON types are serialized normally."""
         data = {
@@ -125,37 +136,36 @@ class TestWithSerializerDecorator:
 
         @with_serializer
         def mock_tool():
-            return {"result": "success"}
+            return {"columns": ["status"], "rows": [["ok"]]}
 
         result = mock_tool()
 
         assert isinstance(result, ToolResult)
-        assert result.content == [TextContent(type="text", text='{"result": "success"}')]
-        assert result.structured_content == {"result": "success"}
+        assert result.structured_content == {"columns": ["status"], "rows": [["ok"]]}
 
     def test_sync_function_with_args(self):
-        """Test decorator works with function arguments."""
+        """Test decorator passes arguments through correctly."""
 
         @with_serializer
-        def mock_tool(arg1, arg2):
-            return {"arg1": arg1, "arg2": arg2}
+        def mock_tool(col, val):
+            return {"columns": [col], "rows": [[val]]}
 
-        result = mock_tool("value1", "value2")
+        result = mock_tool("name", "Alice")
 
         assert isinstance(result, ToolResult)
-        assert result.structured_content == {"arg1": "value1", "arg2": "value2"}
+        assert result.structured_content == {"columns": ["name"], "rows": [["Alice"]]}
 
     def test_sync_function_with_kwargs(self):
-        """Test decorator works with keyword arguments."""
+        """Test decorator passes keyword arguments through correctly."""
 
         @with_serializer
-        def mock_tool(name, age=0):
-            return {"name": name, "age": age}
+        def mock_tool(col, val=None):
+            return {"columns": [col], "rows": [[val]]}
 
-        result = mock_tool(name="Alice", age=30)
+        result = mock_tool(col="score", val=42)
 
         assert isinstance(result, ToolResult)
-        assert result.structured_content == {"name": "Alice", "age": 30}
+        assert result.structured_content == {"columns": ["score"], "rows": [[42]]}
 
     @pytest.mark.asyncio
     async def test_async_function_basic(self):
@@ -163,129 +173,231 @@ class TestWithSerializerDecorator:
 
         @with_serializer
         async def mock_async_tool():
-            return {"result": "async success"}
+            return {"columns": ["status"], "rows": [["ok"]]}
 
         result = await mock_async_tool()
 
         assert isinstance(result, ToolResult)
-        assert result.content == [TextContent(type="text", text='{"result": "async success"}')]
-        assert result.structured_content == {"result": "async success"}
+        assert result.structured_content == {"columns": ["status"], "rows": [["ok"]]}
 
     @pytest.mark.asyncio
     async def test_async_function_with_args(self):
-        """Test decorator works with async function arguments."""
+        """Test decorator passes arguments through correctly for async functions."""
 
         @with_serializer
         async def mock_async_tool(x, y):
-            return {"sum": x + y}
+            return {"columns": ["sum"], "rows": [[x + y]]}
 
         result = await mock_async_tool(5, 10)
 
         assert isinstance(result, ToolResult)
-        assert result.structured_content == {"sum": 15}
+        assert result.structured_content == {"columns": ["sum"], "rows": [[15]]}
 
     def test_custom_types_serialization(self):
-        """Test decorator properly serializes custom types."""
+        """Test decorator normalizes CH-specific types in rows."""
 
         @with_serializer
         def mock_tool():
             return {
-                "ip": ipaddress.IPv4Address("172.16.0.1"),
-                "amount": Decimal("500.00"),
-                "data": b"encoded",
+                "columns": ["ip", "amount", "data"],
+                "rows": [[ipaddress.IPv4Address("172.16.0.1"), Decimal("500.00"), b"encoded"]],
             }
 
         result = mock_tool()
 
         assert isinstance(result, ToolResult)
-        parsed = result.structured_content
-        assert parsed["ip"] == "172.16.0.1"
-        assert parsed["amount"] == "500.00"
-        assert parsed["data"] == "encoded"
+        row = result.structured_content["rows"][0]
+        assert row[0] == "172.16.0.1"
+        assert row[1] == "500.00"
+        assert row[2] == "encoded"
 
     @pytest.mark.asyncio
     async def test_async_custom_types_serialization(self):
-        """Test decorator serializes custom types in async functions."""
+        """Test decorator normalizes CH-specific types in async functions."""
 
         @with_serializer
         async def mock_async_tool():
-            return {"time": time(10, 30, 0), "decimal": Decimal("123.45")}
+            return {"columns": ["t", "decimal"], "rows": [[time(10, 30, 0), Decimal("123.45")]]}
 
         result = await mock_async_tool()
 
         assert isinstance(result, ToolResult)
-        parsed = result.structured_content
-        assert parsed["time"] == "10:30:00"
-        assert parsed["decimal"] == "123.45"
+        row = result.structured_content["rows"][0]
+        assert row[0] == "10:30:00"
+        assert row[1] == "123.45"
 
-    def test_content_structured_content_match(self):
-        """Test that content and structured_content are consistent."""
+
+class TestSerializeQueryResult:
+    """Test suite for _serialize_query_result."""
+
+    def test_query_result_produces_toon(self):
+        """HdxQueryResult shape produces TOON, not JSON."""
+        from mcp_hydrolix.utils import _serialize_query_result
+
+        result = {"columns": ["id", "name"], "rows": [[1, "Alice"], [2, "Bob"]]}
+        toon_str, structured = _serialize_query_result(result)
+
+        # Content should be TOON (not valid JSON)
+        with pytest.raises((json.JSONDecodeError, ValueError)):
+            json.loads(toon_str)
+
+        # TOON header declares 2 rows and the column names
+        assert "[2]" in toon_str
+        assert "id" in toon_str
+        assert "name" in toon_str
+        assert "Alice" in toon_str
+
+    def test_query_result_structured_content_preserves_columnar_format(self):
+        """structured_content keeps the original columns+rows shape."""
+        from mcp_hydrolix.utils import _serialize_query_result
+
+        result = {"columns": ["id", "name"], "rows": [[1, "Alice"], [2, "Bob"]]}
+        _, structured = _serialize_query_result(result)
+
+        assert structured["columns"] == ["id", "name"]
+        assert structured["rows"] == [[1, "Alice"], [2, "Bob"]]
+
+    def test_query_result_empty_rows(self):
+        """Empty rows produce valid TOON for an empty list."""
+        from mcp_hydrolix.utils import _serialize_query_result
+
+        result = {"columns": ["id", "name"], "rows": []}
+        toon_str, structured = _serialize_query_result(result)
+
+        assert "[0]" in toon_str
+        assert structured["rows"] == []
+
+    def test_query_result_single_row(self):
+        """Single-row result encodes correctly."""
+        from mcp_hydrolix.utils import _serialize_query_result
+
+        result = {"columns": ["x"], "rows": [[42]]}
+        toon_str, structured = _serialize_query_result(result)
+
+        assert "[1]" in toon_str
+        assert "42" in toon_str
+
+    def test_query_result_null_value(self):
+        """None values in rows are encoded as null in TOON."""
+        from mcp_hydrolix.utils import _serialize_query_result
+
+        result = {"columns": ["a", "b"], "rows": [[None, 1]]}
+        toon_str, _ = _serialize_query_result(result)
+
+        assert "null" in toon_str
+
+    def test_query_result_normalizes_datetime(self):
+        """datetime in rows is converted to a Unix timestamp before TOON encoding."""
+        from mcp_hydrolix.utils import _serialize_query_result
+
+        dt = datetime(2024, 1, 15, 12, 0, 0)
+        result = {"columns": ["ts"], "rows": [[dt]]}
+        toon_str, structured = _serialize_query_result(result)
+
+        assert str(dt.timestamp()) in toon_str
+        assert structured["rows"][0][0] == dt.timestamp()
+
+    def test_query_result_normalizes_decimal(self):
+        """Decimal in rows is converted to string before TOON encoding."""
+        from mcp_hydrolix.utils import _serialize_query_result
+
+        result = {"columns": ["amount"], "rows": [[Decimal("99.99")]]}
+        toon_str, structured = _serialize_query_result(result)
+
+        assert "99.99" in toon_str
+        assert structured["rows"][0][0] == "99.99"
+
+    def test_query_result_normalizes_ipv4(self):
+        """IPv4Address in rows is converted to string before TOON encoding."""
+        from mcp_hydrolix.utils import _serialize_query_result
+
+        result = {"columns": ["ip"], "rows": [[ipaddress.IPv4Address("1.2.3.4")]]}
+        toon_str, structured = _serialize_query_result(result)
+
+        assert "1.2.3.4" in toon_str
+        assert structured["rows"][0][0] == "1.2.3.4"
+
+    def test_query_result_normalizes_bytes(self):
+        """bytes in rows are decoded to a UTF-8 string before TOON encoding."""
+        from mcp_hydrolix.utils import _serialize_query_result
+
+        result = {"columns": ["data"], "rows": [[b"hello"]]}
+        toon_str, structured = _serialize_query_result(result)
+
+        assert "hello" in toon_str
+        assert structured["rows"][0][0] == "hello"
+
+    def test_query_result_normalizes_ipv6(self):
+        """IPv6Address in rows is converted to string before TOON encoding."""
+        from mcp_hydrolix.utils import _serialize_query_result
+
+        result = {"columns": ["ip"], "rows": [[ipaddress.IPv6Address("2001:db8::1")]]}
+        toon_str, structured = _serialize_query_result(result)
+
+        assert "2001:db8::1" in toon_str
+        assert structured["rows"][0][0] == "2001:db8::1"
+
+    def test_query_result_toon_failure_falls_back_to_json(self):
+        """If toon_encode raises, the result falls back to JSON without crashing."""
+        from unittest.mock import patch
+        from mcp_hydrolix.utils import _serialize_query_result
+
+        result = {"columns": ["a"], "rows": [[1], [2]]}
+        with patch("mcp_hydrolix.utils.toon_encode", side_effect=RuntimeError("boom")):
+            encoded, structured = _serialize_query_result(result)
+
+        # Should be valid JSON, not TOON
+        parsed = json.loads(encoded)
+        assert parsed == [{"a": 1}, {"a": 2}]
+        assert structured["rows"] == [[1], [2]]
+
+    def test_with_serializer_query_result_content_is_toon(self):
+        """with_serializer produces TOON content for HdxQueryResult-shaped returns."""
 
         @with_serializer
-        def mock_tool():
-            return {"key": "value", "number": 42}
+        def mock_query_tool():
+            return {"columns": ["id", "val"], "rows": [[1, "foo"], [2, "bar"]]}
 
-        result: ToolResult = mock_tool()
-
-        # Parse the content string and verify it matches structured_content
-        parsed_content = json.loads(result.content[0].text)
-        assert parsed_content == result.structured_content
-
-    def test_complex_nested_structure(self):
-        """Test decorator handles complex nested structures."""
-
-        @with_serializer
-        def mock_tool():
-            return {
-                "users": [
-                    {
-                        "id": 1,
-                        "ip": ipaddress.IPv4Address("192.168.1.1"),
-                        "balance": Decimal("1000.50"),
-                    },
-                    {
-                        "id": 2,
-                        "ip": ipaddress.IPv4Address("192.168.1.2"),
-                        "balance": Decimal("2000.75"),
-                    },
-                ],
-                "metadata": {"timestamp": time(14, 30, 0), "data": b"metadata"},
-            }
-
-        result = mock_tool()
+        result = mock_query_tool()
 
         assert isinstance(result, ToolResult)
-        parsed = result.structured_content
-        assert len(parsed["users"]) == 2
-        assert parsed["users"][0]["ip"] == "192.168.1.1"
-        assert parsed["users"][0]["balance"] == "1000.50"
-        assert parsed["metadata"]["data"] == "metadata"
+        toon_text = result.content[0].text
+        # TOON, not JSON
+        with pytest.raises((json.JSONDecodeError, ValueError)):
+            json.loads(toon_text)
+        assert "[2]" in toon_text
+        assert "id" in toon_text
+        assert "foo" in toon_text
 
-    def test_empty_result(self):
-        """Test decorator handles empty results."""
-
-        @with_serializer
-        def mock_tool():
-            return {}
-
-        result = mock_tool()
-
-        assert isinstance(result, ToolResult)
-        assert result.content == [TextContent(type="text", text="{}")]
-        assert result.structured_content == {}
-
-    def test_list_result(self):
-        """Test decorator handles list results."""
+    @pytest.mark.asyncio
+    async def test_with_serializer_async_query_result_content_is_toon(self):
+        """with_serializer async variant also produces TOON for query results."""
 
         @with_serializer
-        def mock_tool():
-            return [1, 2, 3, 4, 5]
+        async def mock_async_query_tool():
+            return {"columns": ["a"], "rows": [[10], [20]]}
 
-        result = mock_tool()
+        result = await mock_async_query_tool()
 
-        assert isinstance(result, ToolResult)
-        assert result.content == [TextContent(type="text", text='{"result": [1, 2, 3, 4, 5]}')]
-        assert result.structured_content == {"result": [1, 2, 3, 4, 5]}
+        toon_text = result.content[0].text
+        with pytest.raises((json.JSONDecodeError, ValueError)):
+            json.loads(toon_text)
+        assert "[2]" in toon_text
+        assert "10" in toon_text
+
+    def test_with_serializer_query_result_structured_content(self):
+        """structured_content for a query result keeps the columnar dict."""
+
+        @with_serializer
+        def mock_query_tool():
+            return {"columns": ["x", "y"], "rows": [[1, 2], [3, 4]]}
+
+        result = mock_query_tool()
+
+        assert result.structured_content == {
+            "columns": ["x", "y"],
+            "rows": [[1, 2], [3, 4]],
+        }
 
 
 if __name__ == "__main__":

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,128 +4,57 @@ import pytest
 from datetime import datetime, time
 from decimal import Decimal
 
-from mcp_hydrolix.utils import ExtendedEncoder, with_serializer
+from mcp_hydrolix.utils import _normalize_value, with_serializer
 from fastmcp.tools.tool import ToolResult
 
 
-class TestExtendedEncoder:
-    """Test suite for ExtendedEncoder class."""
+class TestNormalizeValue:
+    """Test suite for _normalize_value."""
 
-    def test_ipv4_address_serialization(self):
-        """Test that IPv4 addresses are serialized to strings."""
-        ip = ipaddress.IPv4Address("192.168.1.1")
-        result = json.dumps({"ip": ip}, cls=ExtendedEncoder)
-        assert result == '{"ip": "192.168.1.1"}'
+    def test_ipv4_address(self):
+        assert _normalize_value(ipaddress.IPv4Address("192.168.1.1")) == "192.168.1.1"
 
-    def test_datetime_serialization(self):
-        """Test that datetime objects are converted to time objects."""
+    def test_ipv6_address(self):
+        assert _normalize_value(ipaddress.IPv6Address("2001:db8::1")) == "2001:db8::1"
+
+    def test_datetime(self):
         dt = datetime(2024, 1, 15, 14, 30, 45, 123456)
-        result = json.dumps({"timestamp": dt}, cls=ExtendedEncoder)
-        expected_time = dt.timestamp()
-        assert result == f'{{"timestamp": {expected_time}}}'
+        assert _normalize_value(dt) == dt.timestamp()
 
-    def test_time_serialization(self):
-        """Test that time objects are converted to seconds."""
-        t = time(14, 30, 45, 123456)
-        result = json.dumps({"time": t}, cls=ExtendedEncoder)
-        expected_time = "14:30:45.123456"
-        assert result == f'{{"time": "{expected_time}"}}'
+    def test_time(self):
+        assert _normalize_value(time(14, 30, 45, 123456)) == "14:30:45.123456"
 
-    def test_time_serialization_midnight(self):
-        """Test time serialization at midnight (edge case)."""
-        t = time(0, 0, 0, 0)
-        result = json.dumps({"time": t}, cls=ExtendedEncoder)
-        assert result == '{"time": "00:00:00"}'
+    def test_time_midnight(self):
+        assert _normalize_value(time(0, 0, 0)) == "00:00:00"
 
-    def test_time_serialization_end_of_day(self):
-        """Test time serialization at end of day (edge case)."""
-        t = time(23, 59, 59, 999999)
-        result = json.dumps({"time": t}, cls=ExtendedEncoder)
-        assert result == '{"time": "23:59:59.999999"}'
+    def test_bytes_utf8(self):
+        assert _normalize_value(b"hello world") == "hello world"
 
-    def test_bytes_serialization(self):
-        """Test that bytes are decoded to strings."""
-        data = b"hello world"
-        result = json.dumps({"data": data}, cls=ExtendedEncoder)
-        assert result == '{"data": "hello world"}'
+    def test_bytes_non_utf8(self):
+        result = _normalize_value(b"\xff\xfe")
+        assert isinstance(result, str)  # did not raise
 
-    def test_bytes_serialization_utf8(self):
-        """Test bytes serialization with UTF-8 characters."""
-        data = "hello 世界".encode("utf-8")
-        result = json.dumps({"data": data}, cls=ExtendedEncoder)
-        assert result == '{"data": "hello 世界"}'.encode("unicode-escape").decode("utf-8")
+    def test_decimal(self):
+        assert _normalize_value(Decimal("123.456")) == "123.456"
 
-    def test_decimal_serialization(self):
-        """Test that Decimal objects are converted to strings."""
-        dec = Decimal("123.456")
-        result = json.dumps({"amount": dec}, cls=ExtendedEncoder)
-        assert result == '{"amount": "123.456"}'
-
-    def test_decimal_serialization_precision(self):
-        """Test Decimal serialization preserves precision."""
+    def test_decimal_preserves_precision(self):
         dec = Decimal("0.123456789012345678901234567890")
-        result = json.dumps({"value": dec}, cls=ExtendedEncoder)
-        assert result == '{"value": "0.123456789012345678901234567890"}'
+        assert _normalize_value(dec) == str(dec)
 
-    def test_combined_types_serialization(self):
-        """Test serialization of multiple custom types together."""
-        data = {
-            "ip": ipaddress.IPv4Address("10.0.0.1"),
-            "time": time(12, 0, 0),
-            "data": b"test",
-            "amount": Decimal("99.99"),
-        }
-        result = json.dumps(data, cls=ExtendedEncoder)
-        parsed = json.loads(result)
+    def test_passthrough_string(self):
+        assert _normalize_value("hello") == "hello"
 
-        assert parsed["ip"] == "10.0.0.1"
-        assert parsed["time"] == "12:00:00"
-        assert parsed["data"] == "test"
-        assert parsed["amount"] == "99.99"
+    def test_passthrough_int(self):
+        assert _normalize_value(42) == 42
 
-    def test_nested_serialization(self):
-        """Test serialization of nested structures."""
-        data = {
-            "users": [
-                {"ip": ipaddress.IPv4Address("192.168.1.100"), "balance": Decimal("1000.50")},
-                {"ip": ipaddress.IPv4Address("192.168.1.101"), "balance": Decimal("2000.75")},
-            ]
-        }
-        result = json.dumps(data, cls=ExtendedEncoder)
-        parsed = json.loads(result)
+    def test_passthrough_float(self):
+        assert _normalize_value(3.14) == 3.14
 
-        assert parsed["users"][0]["ip"] == "192.168.1.100"
-        assert parsed["users"][0]["balance"] == "1000.50"
-        assert parsed["users"][1]["ip"] == "192.168.1.101"
-        assert parsed["users"][1]["balance"] == "2000.75"
+    def test_passthrough_none(self):
+        assert _normalize_value(None) is None
 
-    def test_ipv6_address_serialization(self):
-        """Test that IPv6 addresses are serialized to strings."""
-        ip = ipaddress.IPv6Address("2001:db8::1")
-        result = json.dumps({"ip": ip}, cls=ExtendedEncoder)
-        assert result == '{"ip": "2001:db8::1"}'
-
-    def test_bytes_non_utf8_serialization(self):
-        """Non-UTF-8 bytes are decoded with replacement rather than raising."""
-        data = b"\xff\xfe"  # invalid UTF-8
-        result = json.dumps({"data": data}, cls=ExtendedEncoder)
-        parsed = json.loads(result)
-        assert isinstance(parsed["data"], str)  # did not raise
-
-    def test_standard_types_unchanged(self):
-        """Test that standard JSON types are serialized normally."""
-        data = {
-            "string": "test",
-            "number": 42,
-            "float": 3.14,
-            "boolean": True,
-            "null": None,
-            "list": [1, 2, 3],
-            "dict": {"key": "value"},
-        }
-        result = json.dumps(data, cls=ExtendedEncoder)
-        parsed = json.loads(result)
-        assert parsed == data
+    def test_passthrough_bool(self):
+        assert _normalize_value(True) is True
 
 
 class TestWithSerializerDecorator:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -27,12 +27,11 @@ class TestNormalizeValue:
     def test_time_midnight(self):
         assert _normalize_value(time(0, 0, 0)) == "00:00:00"
 
-    def test_bytes_utf8(self):
-        assert _normalize_value(b"hello world") == "hello world"
+    def test_bytes(self):
+        assert _normalize_value(b"hello") == "aGVsbG8="
 
-    def test_bytes_non_utf8(self):
-        result = _normalize_value(b"\xff\xfe")
-        assert isinstance(result, str)  # did not raise
+    def test_bytes_binary(self):
+        assert _normalize_value(b"\xff\xfe") == "//4="
 
     def test_decimal(self):
         assert _normalize_value(Decimal("123.456")) == "123.456"
@@ -138,7 +137,7 @@ class TestWithSerializerDecorator:
         row = result.structured_content["rows"][0]
         assert row[0] == "172.16.0.1"
         assert row[1] == "500.00"
-        assert row[2] == "encoded"
+        assert row[2] == "ZW5jb2RlZA=="
 
     @pytest.mark.asyncio
     async def test_async_custom_types_serialization(self):
@@ -247,14 +246,14 @@ class TestSerializeQueryResult:
         assert structured["rows"][0][0] == "1.2.3.4"
 
     def test_query_result_normalizes_bytes(self):
-        """bytes in rows are decoded to a UTF-8 string before TOON encoding."""
+        """bytes in rows are base64-encoded before TOON encoding."""
         from mcp_hydrolix.utils import _serialize_query_result
 
         result = {"columns": ["data"], "rows": [[b"hello"]]}
         toon_str, structured = _serialize_query_result(result)
 
-        assert "hello" in toon_str
-        assert structured["rows"][0][0] == "hello"
+        assert "aGVsbG8=" in toon_str
+        assert structured["rows"][0][0] == "aGVsbG8="
 
     def test_query_result_normalizes_ipv6(self):
         """IPv6Address in rows is converted to string before TOON encoding."""

--- a/uv.lock
+++ b/uv.lock
@@ -837,7 +837,7 @@ requires-dist = [
     { name = "pytest-xdist", marker = "extra == 'dev'" },
     { name = "python-dotenv", specifier = ">=1.1,<1.2" },
     { name = "ruff", marker = "extra == 'dev'" },
-    { name = "toon-format", git = "https://github.com/toon-format/toon-python.git" },
+    { name = "toon-format", specifier = ">=0.9.0b1" },
 ]
 provides-extras = ["dev"]
 
@@ -1677,7 +1677,11 @@ wheels = [
 [[package]]
 name = "toon-format"
 version = "0.9.0b1"
-source = { git = "https://github.com/toon-format/toon-python.git#6b26984a01279defdcf40ab9d09bc418fe8133ac" }
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fa/15/d23d6d3e36aa4ec96dd5692bc7715fe17015b669e8f0d1c5c7fa906a3ceb/toon_format-0.9.0b1.tar.gz", hash = "sha256:8f391dd6ad9677c78366bd8eb6762d064a2183f67b9b7da1f348fdb6ee8738e7", size = 87398, upload-time = "2025-11-08T19:22:53.059Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/f3/27ab1d982bb81bf9ac5be70b4c774996eb8562b93c77e93c253c22be951f/toon_format-0.9.0b1-py3-none-any.whl", hash = "sha256:efeee919501f91137f017f7bed34789c067f76178111aa872a49bc8653dce3be", size = 36173, upload-time = "2025-11-08T19:22:51.523Z" },
+]
 
 [[package]]
 name = "truststore"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.13"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
@@ -805,6 +805,7 @@ dependencies = [
     { name = "pip-system-certs" },
     { name = "pyjwt" },
     { name = "python-dotenv" },
+    { name = "toon-format" },
 ]
 
 [package.optional-dependencies]
@@ -836,6 +837,7 @@ requires-dist = [
     { name = "pytest-xdist", marker = "extra == 'dev'" },
     { name = "python-dotenv", specifier = ">=1.1,<1.2" },
     { name = "ruff", marker = "extra == 'dev'" },
+    { name = "toon-format", git = "https://github.com/toon-format/toon-python.git" },
 ]
 provides-extras = ["dev"]
 
@@ -1671,6 +1673,11 @@ sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889a
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
 ]
+
+[[package]]
+name = "toon-format"
+version = "0.9.0b1"
+source = { git = "https://github.com/toon-format/toon-python.git#6b26984a01279defdcf40ab9d09bc418fe8133ac" }
 
 [[package]]
 name = "truststore"


### PR DESCRIPTION
What does this MR do?
-----------------------

Encodes `run_select_query` results in [TOON](https://toonformat.dev) (Token-Oriented Object Notation) instead of JSON. TOON is a compact tabular format designed for LLM consumption — column names are declared once in a header, rows are bare comma-separated values. Expected 30-60% token reduction for typical query results. `structured_content` retains the original columnar format for programmatic consumers.

Does this MR meet the acceptance criteria?
--------------------------------------------

* [x] Documentation created/updated
* [x] Tests added for this feature/bug
* [ ] Does this change request have any security impacts?

Release Notes
---------------------------------------------------

* Major changes:
    * `run_select_query` now returns results in TOON encoding instead of JSON
* Minor changes:
    *
* Bugfixes:
    * `ExtendedEncoder`: `IPv6Address` was unhandled and raised `TypeError`
    * `ExtendedEncoder`: `bytes.decode()` with no encoding crashed on non-UTF-8 binary data
* Issues Closed:
    * HDX-10818
* Security impacts identified:
    *

Testing
--------------------------------------------
**Verify TOON encoding is active**
Run any query via the MCP client and inspect the raw content field — it should be TOON, not JSON:

```python
  result = await client.call_tool("run_select_query", {"query": "SELECT number, toString(number) AS label FROM numbers(5)"})

  print(result.content[0].text)
  # Expected: TOON tabular output, e.g.:
  # [5]{number,label}:
  #   0,0
  #   1,1
  #   ...

  print(result.structured_content)
  # Expected: {"columns": ["number", "label"], "rows": [[0, "0"], [1, "1"], ...]} 
```