### PR TITLE
[IL][HDX-10701] quickstart doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Replace `<your-hydrolix-hostname>`, `<your-username>`, and `<your-password>` wit
 > - **macOS / Linux:** `which mcp-hydrolix`
 > - **Windows:** `where.exe mcp-hydrolix`
 >
-> If `which`/`where.exe` returns nothing, your install location isn't on your PATH. For uv, try `uv tool dir` to find where tools are installed. For pip, run `pip show mcp-hydrolix` and look at the `Location` field, then check `../../../bin/` (macOS/Linux) or `..\Scripts\` (Windows) relative to it.
+> If `which`/`where.exe` returns nothing, your install location isn't on your PATH. For uv, try `uv tool dir --bin` to find where tools are installed. For pip, run `python3 -c "import sysconfig; print(sysconfig.get_path('scripts'))"` (macOS/Linux) or `python -c "import sysconfig; print(sysconfig.get_path('scripts'))"` (Windows) — this prints the exact directory where pip installs executables for your Python installation.
 
 ### Step 4 — Restart Claude Desktop
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,113 @@
 
 An MCP server for Hydrolix.
 
+## Quickstart
+
+Get up and running in a few minutes. This guide covers Claude Desktop (the most common setup) and Claude Code.
+
+### Step 1 — Prerequisites
+
+Before you begin, make sure you have:
+
+- **Hydrolix credentials** — your cluster hostname plus either a username/password or a service account token. If you don't have these, ask your Hydrolix administrator.
+- **Claude Desktop** — download from [claude.ai/download](https://claude.ai/download).
+
+### Step 2 — Install the MCP server
+
+Choose the method that matches your setup:
+
+**Option A: Using uv (recommended)**
+
+[uv](https://docs.astral.sh/uv/) manages Python automatically. If you don't have it, install it first:
+
+macOS / Linux:
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+Windows (PowerShell):
+```powershell
+powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+```
+
+Then install the MCP server:
+```bash
+uv tool install mcp-hydrolix
+```
+
+**Option B: Using pip**
+
+Requires Python 3.13+. If you need to install Python, download it from [python.org](https://www.python.org/downloads/).
+
+```bash
+pip install mcp-hydrolix
+```
+
+### Step 3 — Configure Claude Desktop
+
+1. Open the Claude Desktop configuration file:
+   - **macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
+   - **Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
+
+2. Add the following entry to the `"mcpServers"` object (create the file with this content if it doesn't exist yet):
+
+```json
+{
+  "mcpServers": {
+    "mcp-hydrolix": {
+      "command": "mcp-hydrolix",
+      "env": {
+        "HYDROLIX_HOST": "<your-hydrolix-hostname>",
+        "HYDROLIX_USER": "<your-username>",
+        "HYDROLIX_PASSWORD": "<your-password>"
+      }
+    }
+  }
+}
+```
+
+Replace `<your-hydrolix-hostname>`, `<your-username>`, and `<your-password>` with your actual credentials.
+
+> **Tip:** If the file already has other entries, add the `"mcp-hydrolix"` block inside the existing `"mcpServers"` object rather than replacing the whole file.
+
+> **Using a service account token instead of username/password?** See [Authentication](#authentication).
+
+> **Command not found?** If Claude Desktop can't find `mcp-hydrolix`, replace `"command": "mcp-hydrolix"` with the full path to the binary. Find it by running `which mcp-hydrolix` (macOS/Linux) or `where.exe mcp-hydrolix` (Windows) in your terminal.
+
+### Step 4 — Restart Claude Desktop
+
+Restart the app to apply the configuration.
+
+> **Windows users:** Make sure to fully quit Claude via the system tray icon before restarting.
+
+### Step 5 — Verify it's working
+
+1. Open a new conversation in Claude Desktop. Look for a tools/hammer icon near the text input — this confirms the MCP server connected successfully.
+
+2. Try this prompt to confirm everything is working:
+
+   > Using your Hydrolix MCP tools, list the available databases.
+
+Claude should call the `list_databases` tool and return a list of databases from your cluster.
+
+---
+
+### Using Claude Code instead?
+
+If you prefer the command line, run this after completing [Step 2](#step-2--install-the-mcp-server):
+
+```bash
+claude mcp add --transport stdio hydrolix \
+  --env HYDROLIX_HOST=<your-hydrolix-hostname> \
+  --env HYDROLIX_USER=<your-username> \
+  --env HYDROLIX_PASSWORD=<your-password> \
+  -- mcp-hydrolix
+```
+
+Then open Claude Code and test with the same prompt:
+
+> Using your Hydrolix MCP tools, list the available databases.
+
 ## Tools
 
 * `run_select_query`

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Choose the method that matches your setup:
 
 **Option A: Using uv (recommended)**
 
-[uv](https://docs.astral.sh/uv/) manages Python automatically. If you don't have it, install it first:
+[uv](https://docs.astral.sh/uv/) manages Python automatically and downloads mcp-hydrolix on demand, so no separate install step is needed. If you don't have uv, install it:
 
 macOS / Linux:
 ```bash
@@ -33,11 +33,6 @@ curl -LsSf https://astral.sh/uv/install.sh | sh
 Windows (PowerShell):
 ```powershell
 powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
-```
-
-Then install the MCP server:
-```bash
-uv tool install mcp-hydrolix
 ```
 
 **Option B: Using pip**
@@ -61,7 +56,14 @@ pip install mcp-hydrolix
 {
   "mcpServers": {
     "mcp-hydrolix": {
-      "command": "mcp-hydrolix",
+      "command": "uvx",
+      "args": [
+        "--python",
+        "3.13",
+        "--refresh-package",
+        "mcp-hydrolix",
+        "mcp-hydrolix"
+      ],
       "env": {
         "HYDROLIX_HOST": "<your-hydrolix-hostname>",
         "HYDROLIX_USER": "<your-username>",
@@ -74,21 +76,29 @@ pip install mcp-hydrolix
 
 Replace `<your-hydrolix-hostname>`, `<your-username>`, and `<your-password>` with your actual credentials.
 
+> **Using Option B (pip)?** Use `"command": "mcp-hydrolix"` with no `"args"` field instead.
+
 > **Tip:** If the file already has other entries, add the `"mcp-hydrolix"` block inside the existing `"mcpServers"` object rather than replacing the whole file.
 
 > **Using a service account token instead of username/password?** See [Authentication](#authentication).
 
-> **Command not found?** Claude Desktop launches without your shell's PATH, so it may not locate the `mcp-hydrolix` binary even if installation succeeded. Find the full path by running the appropriate command in your terminal and use it as the `"command"` value in the config:
+> **Command not found?** Claude Desktop launches without your shell's PATH, so it may not locate the binary even if it is installed. Find the full path and use it as the `"command"` value in the config:
+>
+> Option A (uv): find `uvx`:
+> - **macOS / Linux:** `which uvx`
+> - **Windows:** `where.exe uvx`
+>
+> Option B (pip): find `mcp-hydrolix`:
 > - **macOS / Linux:** `which mcp-hydrolix`
 > - **Windows:** `where.exe mcp-hydrolix`
 >
-> If `which`/`where.exe` returns nothing, your install location isn't on your PATH. For uv, try `uv tool dir --bin` to find where tools are installed. For pip, run `python3 -c "import sysconfig; print(sysconfig.get_path('scripts'))"` (macOS/Linux) or `python -c "import sysconfig; print(sysconfig.get_path('scripts'))"` (Windows) — this prints the directory where pip placed the executable. Run it using the same Python interpreter you used to pip install (e.g., activate your virtual environment first if you used one).
+> If `which`/`where.exe` returns nothing, the install location isn't on your PATH. For pip, run `python3 -c "import sysconfig; print(sysconfig.get_path('scripts'))"` (macOS/Linux) or `python -c "import sysconfig; print(sysconfig.get_path('scripts'))"` (Windows) to find where pip placed the executable. Run it using the same Python interpreter you used to pip install (e.g., activate your virtual environment first if you used one).
 
 ### Step 4 — Restart Claude Desktop
 
 Restart the app to apply the configuration.
 
-> **Windows users:** Make sure to fully quit Claude via the system tray icon before restarting.
+> **macOS / Windows users:** Make sure to fully quit Claude before restarting. On macOS, use the menu bar icon or press Cmd+Q. On Windows, use the system tray icon.
 
 ### Step 5 — Verify it's working
 
@@ -104,7 +114,7 @@ Claude should call the `list_databases` tool and return a list of databases from
 
 ### Using Claude Code instead?
 
-If you prefer the command line, run this after completing [Step 2](#step-2--install-the-mcp-server):
+If you prefer the command line, make sure uv is installed (Option A from [Step 2](#step-2--install-the-mcp-server)), then run:
 
 ```bash
 claude mcp add --transport stdio hydrolix \
@@ -112,7 +122,7 @@ claude mcp add --transport stdio hydrolix \
   --env HYDROLIX_USER=<your-username> \
   --env HYDROLIX_PASSWORD=<your-password> \
   --env HYDROLIX_MCP_SERVER_TRANSPORT=stdio \
-  -- mcp-hydrolix
+  -- uvx --python 3.13 --refresh-package mcp-hydrolix mcp-hydrolix
 ```
 
 Then open Claude Code and test with the same prompt:
@@ -182,13 +192,12 @@ MCP Server definition using username and password (JSON):
 
 ```json
 {
-  "command": "uv",
+  "command": "uvx",
   "args": [
-    "run",
-    "--with",
-    "mcp-hydrolix",
     "--python",
     "3.13",
+    "--refresh-package",
+    "mcp-hydrolix",
     "mcp-hydrolix"
   ],
   "env": {
@@ -203,13 +212,12 @@ MCP Server definition using service account token (JSON):
 
 ```json
 {
-  "command": "uv",
+  "command": "uvx",
   "args": [
-    "run",
-    "--with",
-    "mcp-hydrolix",
     "--python",
     "3.13",
+    "--refresh-package",
+    "mcp-hydrolix",
     "mcp-hydrolix"
   ],
   "env": {
@@ -222,13 +230,12 @@ MCP Server definition using service account token (JSON):
 MCP Server definition using username and password (YAML):
 
 ```yaml
-command: uv
+command: uvx
 args:
-- run
-- --with
-- mcp-hydrolix
 - --python
 - "3.13"
+- --refresh-package
+- mcp-hydrolix
 - mcp-hydrolix
 env:
   HYDROLIX_HOST: <hydrolix-host>
@@ -239,13 +246,12 @@ env:
 MCP Server definition using service account token (YAML):
 
 ```yaml
-command: uv
+command: uvx
 args:
-- run
-- --with
-- mcp-hydrolix
 - --python
 - "3.13"
+- --refresh-package
+- mcp-hydrolix
 - mcp-hydrolix
 env:
   HYDROLIX_HOST: <hydrolix-host>
@@ -264,13 +270,12 @@ env:
 {
   "mcpServers": {
     "mcp-hydrolix": {
-      "command": "uv",
+      "command": "uvx",
       "args": [
-        "run",
-        "--with",
-        "mcp-hydrolix",
         "--python",
         "3.13",
+        "--refresh-package",
+        "mcp-hydrolix",
         "mcp-hydrolix"
       ],
       "env": {
@@ -289,13 +294,12 @@ To leverage service account use the following config block:
 {
   "mcpServers": {
     "mcp-hydrolix": {
-      "command": "uv",
+      "command": "uvx",
       "args": [
-        "run",
-        "--with",
-        "mcp-hydrolix",
         "--python",
         "3.13",
+        "--refresh-package",
+        "mcp-hydrolix",
         "mcp-hydrolix"
       ],
       "env": {
@@ -309,7 +313,7 @@ To leverage service account use the following config block:
 
 3. Update the environment variable definitions to point to your Hydrolix cluster.
 
-4. (Recommended) Locate the command entry for `uv` and replace it with the absolute path to the `uv` executable. This ensures that the correct version of `uv` is used when starting the server. You can find this path using `which uv` or `where.exe uv`.
+4. (Recommended) Locate the command entry for `uvx` and replace it with the absolute path to the `uvx` executable. This ensures that the correct version of `uvx` is used when starting the server. You can find this path using `which uvx` or `where.exe uvx`.
 
 5. Restart Claude Desktop to apply the changes. If you are using Windows, ensure Claude is stopped completely by closing the client using the system tray icon.
 
@@ -323,7 +327,7 @@ claude mcp add --transport stdio hydrolix \
   --env HYDROLIX_PASSWORD=<hydrolix-password> \
   --env HYDROLIX_HOST=<hydrolix-host> \
   --env HYDROLIX_MCP_SERVER_TRANSPORT=stdio \
-  -- uv run --with mcp-hydrolix --python 3.13 mcp-hydrolix
+  -- uvx --python 3.13 --refresh-package mcp-hydrolix mcp-hydrolix
 ```
 
 ### Environment Variables

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ pip install mcp-hydrolix
 1. Open the Claude Desktop configuration file:
    - **macOS:** `~/Library/Application Support/Claude/claude_desktop_config.json`
    - **Windows:** `%APPDATA%\Claude\claude_desktop_config.json`
+   - **Linux:** `~/.config/Claude/claude_desktop_config.json`
 
 2. Add the following entry to the `"mcpServers"` object (create the file with this content if it doesn't exist yet):
 
@@ -77,7 +78,11 @@ Replace `<your-hydrolix-hostname>`, `<your-username>`, and `<your-password>` wit
 
 > **Using a service account token instead of username/password?** See [Authentication](#authentication).
 
-> **Command not found?** If Claude Desktop can't find `mcp-hydrolix`, replace `"command": "mcp-hydrolix"` with the full path to the binary. Find it by running `which mcp-hydrolix` (macOS/Linux) or `where.exe mcp-hydrolix` (Windows) in your terminal.
+> **Command not found?** Claude Desktop launches without your shell's PATH, so it may not locate the `mcp-hydrolix` binary even if installation succeeded. Find the full path by running the appropriate command in your terminal and use it as the `"command"` value in the config:
+> - **macOS / Linux:** `which mcp-hydrolix`
+> - **Windows:** `where.exe mcp-hydrolix`
+>
+> If `which`/`where.exe` returns nothing, your install location isn't on your PATH. For uv, try `uv tool dir` to find where tools are installed. For pip, run `pip show mcp-hydrolix` and look at the `Location` field, then check `../../../bin/` (macOS/Linux) or `..\Scripts\` (Windows) relative to it.
 
 ### Step 4 — Restart Claude Desktop
 
@@ -106,6 +111,7 @@ claude mcp add --transport stdio hydrolix \
   --env HYDROLIX_HOST=<your-hydrolix-hostname> \
   --env HYDROLIX_USER=<your-username> \
   --env HYDROLIX_PASSWORD=<your-password> \
+  --env HYDROLIX_MCP_SERVER_TRANSPORT=stdio \
   -- mcp-hydrolix
 ```
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Replace `<your-hydrolix-hostname>`, `<your-username>`, and `<your-password>` wit
 
 Restart the app to apply the configuration.
 
-> **macOS / Windows users:** Make sure to fully quit Claude before restarting. On macOS, use the menu bar icon or press Cmd+Q. On Windows, use the system tray icon.
+> **macOS / Windows users:** Make sure to fully quit Claude before restarting. On macOS, press Cmd+Q or right-click the Dock icon and choose Quit. On Windows, use the system tray icon.
 
 ### Step 5 — Verify it's working
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ An MCP server for Hydrolix.
 
 ## Quickstart
 
-Get up and running in a few minutes. This guide covers Claude Desktop (the most common setup) and Claude Code.
+Get up and running in a few minutes. This section covers Claude Desktop and Claude Code.
 
 ### Step 1 — Prerequisites
 

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Replace `<your-hydrolix-hostname>`, `<your-username>`, and `<your-password>` wit
 > - **macOS / Linux:** `which mcp-hydrolix`
 > - **Windows:** `where.exe mcp-hydrolix`
 >
-> If `which`/`where.exe` returns nothing, your install location isn't on your PATH. For uv, try `uv tool dir --bin` to find where tools are installed. For pip, run `python3 -c "import sysconfig; print(sysconfig.get_path('scripts'))"` (macOS/Linux) or `python -c "import sysconfig; print(sysconfig.get_path('scripts'))"` (Windows) — this prints the exact directory where pip installs executables for your Python installation.
+> If `which`/`where.exe` returns nothing, your install location isn't on your PATH. For uv, try `uv tool dir --bin` to find where tools are installed. For pip, run `python3 -c "import sysconfig; print(sysconfig.get_path('scripts'))"` (macOS/Linux) or `python -c "import sysconfig; print(sysconfig.get_path('scripts'))"` (Windows) — this prints the directory where pip placed the executable. Run it using the same Python interpreter you used to pip install (e.g., activate your virtual environment first if you used one).
 
 ### Step 4 — Restart Claude Desktop
 


### PR DESCRIPTION
What does this MR do?
-----------------------
Adds a quickstart section to the README for less technically knowledgeable users. The section provides a linear, step-by-step guide targeting Claude Desktop as the primary path with a Claude Code alternative. Installation instructions cover both `uv tool install` and `pip install` from PyPI.

Does this MR meet the acceptance criteria?
--------------------------------------------

* [x] Documentation created/updated
* [ ] Tests added for this feature/bug
* [ ] Does this change request have any security impacts?

Release Notes
---------------------------------------------------

* Major changes:
    *
* Minor changes:
    * Added beginner-friendly quickstart section to README covering Claude Desktop and Claude Code setup
* Bugfixes:
    *
* Issues Closed:
    *
* Security impacts identified:
    *

Testing
--------------------------------------------
