### PR TITLE
[IL][HDX-11134] Version bump job for publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,3 +1,5 @@
+name: Publish release
+
 on:
   push:
     tags:
@@ -69,3 +71,76 @@ jobs:
         run: |
           docker push us-docker.pkg.dev/hdx-art/t/mcp-hydrolix:${{ steps.get_tag.outputs.tag }}
           docker push us-docker.pkg.dev/hdx-art/t/mcp-hydrolix:latest
+  bump-version:
+    name: Bump to next patch version
+    needs: [publish, publish-docker]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a  # v4
+        with:
+          role-to-assume: arn:aws:iam::471112700926:role/github-actions-lke-secrets-role
+          aws-region: us-east-2
+      - name: Retrieve GitHub App secret
+        id: get-secret
+        run: |
+          secret=$(aws secretsmanager get-secret-value \
+            --secret-id arn:aws:secretsmanager:us-east-2:471112700926:secret:ci/development/mcp-hydrolix/APP_SECRET-93IGLx \
+            --query SecretString --output text)
+          app_id=$(echo "$secret" | jq -r '.APP_ID')
+          private_key=$(echo "$secret" | jq -r '.PRIVATE_KEY')
+          echo "::add-mask::$app_id"
+          echo "$private_key" | while IFS= read -r line; do
+            [ -n "$line" ] && echo "::add-mask::$line"
+          done
+          echo "app-id=$app_id" >> "$GITHUB_OUTPUT"
+          {
+            echo 'private-key<<PRIVATE_KEY_EOF'
+            echo "$private_key"
+            echo 'PRIVATE_KEY_EOF'
+          } >> "$GITHUB_OUTPUT"
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547  # v1
+        with:
+          app-id: ${{ steps.get-secret.outputs.app-id }}
+          private-key: ${{ steps.get-secret.outputs.private-key }}
+      - name: Checkout main
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+        with:
+          ref: main
+          token: ${{ steps.app-token.outputs.token }}
+      - name: Set up uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
+      - name: Install Python
+        run: uv python install
+      - name: Bump patch version
+        run: |
+          current=$(uv version --short)
+          IFS='.' read -r major minor patch <<< "$current"
+          next="$major.$minor.$((patch + 1))"
+          uv version "$next"
+          uv lock --no-upgrade
+          echo "current=$current" >> "$GITHUB_ENV"
+          echo "next=$next" >> "$GITHUB_ENV"
+      - name: Create pull request
+        run: |
+          branch="version/start-${next}-cycle"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$branch"
+          git add pyproject.toml uv.lock
+          git commit -m "Prepare ${next} development cycle"
+          git push -u origin "$branch"
+          gh pr create \
+            --base main \
+            --head "$branch" \
+            --title "Prepare ${next} development cycle" \
+            --body "Automated version bump after publishing v${current}."
+          gh pr merge --auto --squash "$branch"
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -78,7 +78,6 @@ jobs:
     permissions:
       id-token: write
       contents: write
-      pull-requests: write
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a  # v4
@@ -127,20 +126,10 @@ jobs:
           uv lock --no-upgrade
           echo "current=$current" >> "$GITHUB_ENV"
           echo "next=$next" >> "$GITHUB_ENV"
-      - name: Create pull request
+      - name: Push version bump
         run: |
-          branch="version/start-${next}-cycle"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git checkout -b "$branch"
           git add pyproject.toml uv.lock
           git commit -m "Prepare ${next} development cycle"
-          git push -u origin "$branch"
-          gh pr create \
-            --base main \
-            --head "$branch" \
-            --title "Prepare ${next} development cycle" \
-            --body "Automated version bump after publishing v${current}."
-          gh pr merge --auto --squash "$branch"
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          git push origin main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -77,7 +77,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
-      contents: write
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a  # v4
@@ -92,10 +91,16 @@ jobs:
             --query SecretString --output text)
           app_id=$(echo "$secret" | jq -r '.APP_ID')
           private_key=$(echo "$secret" | jq -r '.PRIVATE_KEY')
+          if [[ -z "$app_id" || "$app_id" == "null" ]]; then
+            echo "::error::APP_ID is missing or null in the retrieved secret"
+            exit 1
+          fi
+          if [[ -z "$private_key" || "$private_key" == "null" ]]; then
+            echo "::error::PRIVATE_KEY is missing or null in the retrieved secret"
+            exit 1
+          fi
           echo "::add-mask::$app_id"
-          echo "$private_key" | while IFS= read -r line; do
-            [ -n "$line" ] && echo "::add-mask::$line"
-          done
+          echo "::add-mask::$private_key"
           echo "app-id=$app_id" >> "$GITHUB_OUTPUT"
           {
             echo 'private-key<<PRIVATE_KEY_EOF'
@@ -120,6 +125,10 @@ jobs:
       - name: Bump patch version
         run: |
           current=$(uv version --short)
+          if [[ ! "$current" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Unexpected version format from uv: '$current' (expected X.Y.Z)"
+            exit 1
+          fi
           IFS='.' read -r major minor patch <<< "$current"
           next="$major.$minor.$((patch + 1))"
           uv version "$next"
@@ -131,5 +140,9 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add pyproject.toml uv.lock
+          if git diff --cached --quiet; then
+            echo "::notice::No changes to commit -- version may already be bumped"
+            exit 0
+          fi
           git commit -m "Prepare ${next} development cycle"
           git push origin main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -89,6 +89,7 @@ jobs:
           secret=$(aws secretsmanager get-secret-value \
             --secret-id arn:aws:secretsmanager:us-east-2:471112700926:secret:ci/development/mcp-hydrolix/APP_SECRET-93IGLx \
             --query SecretString --output text)
+          echo "::add-mask::$secret"
           app_id=$(echo "$secret" | jq -r '.APP_ID')
           private_key=$(echo "$secret" | jq -r '.PRIVATE_KEY')
           if [[ -z "$app_id" || "$app_id" == "null" ]]; then
@@ -137,6 +138,10 @@ jobs:
           echo "next=$next" >> "$GITHUB_ENV"
       - name: Push version bump
         run: |
+          if [[ -z "$next" ]]; then
+            echo "::error::next version variable is empty; the version bump step may have failed"
+            exit 1
+          fi
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add pyproject.toml uv.lock


### PR DESCRIPTION
What does this MR do?
-----------------------
Adds a `bump-version` job to the publish workflow. After a successful PyPI and Docker release, the job retrieves a GitHub App token from AWS Secrets Manager via OIDC, bumps the patch version in `pyproject.toml`, regenerates `uv.lock`, and commits and pushes directly to `main` using the GH app token.

Does this MR meet the acceptance criteria?
--------------------------------------------

* [x] Documentation created/updated
* [x] Tests added for this feature/bug
* [x] Does this change request have any security impacts?

Release Notes
---------------------------------------------------

* Major changes:
    *
* Minor changes:
    *  Release pipeline now automatically bumps the patch version and pushes to `main` after each successful publish
* Bugfixes:
    *
* Issues Closed:
    * HDX-11134
* Security impacts identified:
    * The job uses GitHub OIDC to assume an IAM role and retrieve GitHub App credentials from AWS Secrets Manager. Both app_id and private_key values are masked in logs via `add-mask` command before being used. 
    * All GH actions are pinned to commit hashes.

Testing
--------------------------------------------
Push a `vX.Y.Z` tag pointing to a commit on `main`. After the PyPI and Docker jobs succeed, verify that a commit titled "Prepare X.Y.(Z+1) development cycle" appears on `main` and that `pyproject.toml` and `uv.lock` reflect the new version.