### PR TITLE
[IL] [MCP] [AIKIDO] fix: pin GitHub Actions to commit hashes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
     name: Verify tag is on main
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
         with:
           fetch-depth: 0
       - name: Check that tagged commit is on main
@@ -29,27 +29,27 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v5
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+      - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
       - run: uv python install
       - run: uv build
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b  # release/v1
   publish-docker:
     name: Upload release to GAR
     needs: prove-main
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
       - name: Setup uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
       - name: Authenticate GAR
-        uses: google-github-actions/auth@v3
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093  # v3
         with:
           # Key ID: 98941823000cead5a61777398bd450e3e19539c3
           credentials_json: ${{ secrets.GCP_GKE_CI_KEY }}
       - name: "Set up GCP SDK" # needs to be done after google-github-actions/auth but before `gcloud auth configure-docker`
-        uses: google-github-actions/setup-gcloud@v3
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db  # v3
       - name: Configure GAR for docker
         run: gcloud auth configure-docker us-docker.pkg.dev --quiet
       - name: Get tag

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,18 +8,18 @@ jobs:
   core-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions/setup-python@v6
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6
         with:
           python-version: '3.13'
       - name: Pre-commit
-        uses: pre-commit/action@v3.0.1
+        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  # v3.0.1
         with:
           extra_args: --all-files
       - name: Build and run Docker Compose services
         run: docker compose up -d --wait --wait-timeout 300
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78  # v7
       - name: Run tests
         working-directory: .
         run: |


### PR DESCRIPTION
What does this MR do?
-----------------------

Pin all unpinned third-party GitHub Actions to commit hashes to prevent supply chain attacks. Version tags are preserved as comments.

Does this MR meet the acceptance criteria?
--------------------------------------------

* [ ] Documentation created/updated
* [ ] Tests added for this feature/bug
* [ ] Does this change request have any security impacts?

Release Notes
---------------------------------------------------

* Major changes:
    * fix: pin GitHub Actions to commit hashes
* Minor changes:
    *
* Bugfixes:
    *
* Issues Closed:
    * https://app.aikido.dev/issues/15539202/detail
* Security impacts identified:
    *

Testing
--------------------------------------------
