### PR TITLE
Clean up tool result types

### DIFF
--- a/mcp_hydrolix/mcp_server.py
+++ b/mcp_hydrolix/mcp_server.py
@@ -23,7 +23,6 @@ from dotenv import load_dotenv
 from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
 from fastmcp.server.dependencies import get_access_token
-from fastmcp.tools.tool import ToolResult
 from fastmcp.server.middleware import Middleware, MiddlewareContext
 from jwt import DecodeError
 from mcp.types import ToolAnnotations
@@ -46,11 +45,14 @@ from mcp_hydrolix.column_analysis import (
 )
 from mcp_hydrolix.models import (
     ColumnType,
+    DatabaseList,
     HdxQueryResult,
+    RunSelectQueryResult,
     SummaryColumn,
     Table,
+    TableList,
 )
-from mcp_hydrolix.utils import inject_limit, with_serializer
+from mcp_hydrolix.utils import coerce_rows, inject_limit
 
 
 MCP_SERVER_NAME = "mcp-hydrolix"
@@ -371,7 +373,7 @@ async def _describe_columns(database: str, table_name: str) -> list[ColumnType]:
         openWorldHint=True,
     )
 )
-async def list_databases() -> List[str]:
+async def list_databases() -> DatabaseList:
     """List available Hydrolix databases"""
     logger.info("Listing all databases")
     result = await execute_cmd("SHOW DATABASES")
@@ -383,7 +385,7 @@ async def list_databases() -> List[str]:
         databases = [result]
 
     logger.info(f"Found {len(databases)} databases")
-    return databases
+    return DatabaseList(databases=databases)
 
 
 @mcp.tool(
@@ -469,7 +471,7 @@ async def get_table_info(database: str, table: str) -> Table:
 )
 async def list_tables(
     database: str, like: Optional[str] = None, not_like: Optional[str] = None
-) -> List[Table]:
+) -> TableList:
     """List all tables in a database for exploration and discovery.
 
     Use this tool to:
@@ -519,7 +521,7 @@ async def list_tables(
     logger.info(
         f"Found {len(tables)} tables (columns not populated - use get_table_info for schema)"
     )
-    return tables
+    return TableList(tables=tables)
 
 
 def _resolve_cell_limit(max_cells: Optional[int]) -> tuple[int, bool]:
@@ -543,8 +545,8 @@ def _build_truncation_response(
     rows: list,
     cell_limit: int,
     capped_by_operator: bool,
-) -> dict:
-    """Build the truncated response dict, logging the truncation event.
+) -> RunSelectQueryResult:
+    """Build the truncated response, logging the truncation event.
 
     Precondition: len(columns) > 0 (caller already guards this).
     """
@@ -571,13 +573,13 @@ def _build_truncation_response(
             "(e.g. max_cells=200000), or set max_cells=0 to disable truncation entirely."
         )
 
-    return {
-        "columns": columns,
-        "rows": rows[:max_rows],
-        "truncated": True,
-        "row_count": max_rows,
-        "total_row_count": num_rows,
-        "message": (
+    return RunSelectQueryResult(
+        columns=columns,
+        rows=coerce_rows(rows[:max_rows]),
+        truncated=True,
+        row_count=max_rows,
+        total_row_count=num_rows,
+        message=(
             f"Result truncated: showing {max_rows:,} of {num_rows:,} fetched rows "
             f"({num_cols} columns). "
             f"Exceeded the cell limit of {cell_limit:,} "
@@ -590,7 +592,7 @@ def _build_truncation_response(
             )
             + retrieve_more
         ),
-    }
+    )
 
 
 @mcp.tool(
@@ -602,11 +604,10 @@ def _build_truncation_response(
         openWorldHint=True,
     )
 )
-@with_serializer
 async def run_select_query(
     query: str,
     max_cells: Optional[int] = None,
-) -> ToolResult:
+) -> RunSelectQueryResult:
     """Run a SELECT query in a Hydrolix time-series database using the Clickhouse SQL dialect.
     Queries run using this tool will timeout after 30 seconds.
 
@@ -766,4 +767,9 @@ async def run_select_query(
     if cell_limit > 0 and num_cols > 0 and num_rows * num_cols > cell_limit:
         return _build_truncation_response(columns, rows, cell_limit, capped_by_operator)
 
-    return {"columns": columns, "rows": rows, "truncated": False, "row_count": num_rows}
+    return RunSelectQueryResult(
+        columns=columns,
+        rows=coerce_rows(rows),
+        truncated=False,
+        row_count=num_rows,
+    )

--- a/mcp_hydrolix/models.py
+++ b/mcp_hydrolix/models.py
@@ -1,60 +1,87 @@
-import dataclasses as _dc
-from dataclasses import dataclass
-from typing import Annotated, Any, ClassVar, List, Optional, TypedDict, Union, get_type_hints
+from typing import (
+    Annotated,
+    Any,
+    List,
+    Literal,
+    Optional,
+    TypedDict,
+    Union,
+    get_type_hints,
+)
 
-from pydantic import Field, field_serializer, model_serializer
+from pydantic import Field, model_serializer
 from pydantic.dataclasses import dataclass as pydantic_dataclass
 
 
-@dataclass(frozen=True)
+def _strip_empty(self, handler) -> dict:
+    """Drop None and empty-string fields from the serialized dict (token saver)."""
+    return {k: v for k, v in handler(self).items() if v is not None and v != ""}
+
+
+@pydantic_dataclass(frozen=True)
 class Column:
     """A plain dimension column."""
-
-    column_category: ClassVar[str] = "Column"
 
     name: str
     type: str
     comment: Optional[str] = None
+    column_category: Literal["Column"] = "Column"
+
+    @model_serializer(mode="wrap")
+    def _serialize(self, handler) -> dict:
+        return _strip_empty(self, handler)
 
 
-@dataclass(frozen=True)
+@pydantic_dataclass(frozen=True)
 class AliasColumn:
     """A grouper/dimension alias."""
-
-    column_category: ClassVar[str] = "AliasColumn"
 
     name: str
     type: str
     default_expr: str
     comment: Optional[str] = None
+    column_category: Literal["AliasColumn"] = "AliasColumn"
+
+    @model_serializer(mode="wrap")
+    def _serialize(self, handler) -> dict:
+        return _strip_empty(self, handler)
 
 
-@dataclass(frozen=True)
+@pydantic_dataclass(frozen=True)
 class AggregateColumn:
     """A column with AggregateFunction or SimpleAggregateFunction type."""
-
-    column_category: ClassVar[str] = "AggregateColumn"
 
     name: str
     type: str
     base_function: str
     merge_function: str
     comment: Optional[str] = None
+    column_category: Literal["AggregateColumn"] = "AggregateColumn"
+
+    @model_serializer(mode="wrap")
+    def _serialize(self, handler) -> dict:
+        return _strip_empty(self, handler)
 
 
-@dataclass(frozen=True)
+@pydantic_dataclass(frozen=True)
 class SummaryColumn:
     """An ALIAS column that transitively depends on aggregate functions."""
-
-    column_category: ClassVar[str] = "SummaryColumn"
 
     name: str
     type: str
     default_expr: str
     comment: Optional[str] = None
+    column_category: Literal["SummaryColumn"] = "SummaryColumn"
+
+    @model_serializer(mode="wrap")
+    def _serialize(self, handler) -> dict:
+        return _strip_empty(self, handler)
 
 
-ColumnType = Union[Column, AliasColumn, AggregateColumn, SummaryColumn]
+ColumnType = Annotated[
+    Union[Column, AliasColumn, AggregateColumn, SummaryColumn],
+    Field(discriminator="column_category"),
+]
 
 
 class _SystemCol:
@@ -83,24 +110,11 @@ class Table:
     is_summary_table: Optional[bool] = None
     summary_table_info: Optional[str] = None
 
-    @field_serializer("columns")
-    def serialize_columns(self, columns: Optional[List[ColumnType]]) -> List[dict]:
-        return [
-            {
-                k: v
-                for k, v in {
-                    **_dc.asdict(col),
-                    "column_category": type(col).column_category,
-                }.items()
-                if v is not None and v != ""
-            }
-            for col in (columns or [])
-        ]
-
     @model_serializer(mode="wrap")
     def serialize_table(self, handler) -> dict:
-        # handler runs Pydantic's default serialization (including serialize_columns)
-        # and returns the result as a dict, which we then filter.
+        # handler runs Pydantic's default serialization (which now invokes each
+        # column type's own _strip_empty serializer) and returns a dict, which
+        # we then filter at the table level.
         d = handler(self)
         return {k: v for k, v in d.items() if v is not None and v != ""}
 

--- a/mcp_hydrolix/models.py
+++ b/mcp_hydrolix/models.py
@@ -132,3 +132,46 @@ class Table:
 class HdxQueryResult(TypedDict):
     columns: List[str]
     rows: List[List[Any]]
+
+
+@pydantic_dataclass(frozen=True)
+class DatabaseList:
+    """Result of `list_databases` — wraps a list of database names so the
+    structured payload is a JSON object (as MCP requires) with an explicit
+    field name instead of fastmcp's generic `result` wrapper."""
+
+    databases: List[str]
+
+
+@pydantic_dataclass(frozen=True)
+class TableList:
+    """Result of `list_tables` — wraps a list of tables so the structured
+    payload is a JSON object (as MCP requires) with an explicit field name
+    instead of fastmcp's generic `result` wrapper."""
+
+    tables: List[Table]
+
+
+@pydantic_dataclass(frozen=True)
+class RunSelectQueryResult:
+    """Stable typed shape for `run_select_query`.
+
+    `total_row_count` and `message` are only meaningful when `truncated=True`;
+    they default to None and are stripped from the wire payload by the
+    serializer when absent (token saver). Schema still declares them Optional
+    so strict clients accept the missing fields.
+
+    `rows` cells are passed through as-is — `null`s inside user query results
+    are kept (they may be meaningful data from the user's SELECT).
+    """
+
+    columns: List[str]
+    rows: List[List[Any]]
+    truncated: bool
+    row_count: int
+    total_row_count: Optional[int] = None
+    message: Optional[str] = None
+
+    @model_serializer(mode="wrap")
+    def _serialize(self, handler) -> dict:
+        return {k: v for k, v in handler(self).items() if v is not None}

--- a/mcp_hydrolix/utils.py
+++ b/mcp_hydrolix/utils.py
@@ -1,73 +1,39 @@
-import inspect
 import ipaddress
-import json
 import logging
 from datetime import date, datetime, time
 from decimal import Decimal
-from functools import wraps
+from typing import Any, List
 
 import sqlglot
 import sqlglot.errors as sqlglot_errors
 import sqlglot.expressions as exp
-from fastmcp.tools.tool import ToolResult
 
 logger = logging.getLogger(__name__)
 
 
-class ExtendedEncoder(json.JSONEncoder):
-    """Extends JSONEncoder to apply custom serialization of CH data types."""
+def coerce_cell(v: Any) -> Any:
+    """Coerce ClickHouse-specific Python types in a result cell to JSON-friendly
+    equivalents.
 
-    def default(self, obj):
-        if isinstance(obj, ipaddress.IPv4Address):
-            return str(obj)
-        if isinstance(obj, datetime):
-            return obj.timestamp()
-        if isinstance(obj, (date, time)):
-            return obj.isoformat()
-        if isinstance(obj, bytes):
-            return obj.decode()
-        if isinstance(obj, Decimal):
-            return str(obj)
-        return super().default(obj)
-
-
-def with_serializer(fn):
+    `null` values pass through unchanged — `None` in a query result is data
+    (the user's SELECT may legitimately return SQL NULLs) and must be preserved.
     """
-    Decorator to apply custom serialization to CH query tool result.
-    Should be applied as a first decorator of the tool function.
+    if isinstance(v, ipaddress.IPv4Address):
+        return str(v)
+    if isinstance(v, datetime):
+        return v.timestamp()
+    if isinstance(v, (date, time)):
+        return v.isoformat()
+    if isinstance(v, bytes):
+        return v.decode()
+    if isinstance(v, Decimal):
+        return str(v)
+    return v
 
-    :returns: sync/async wrapper of mcp tool function
-    """
 
-    @wraps(fn)
-    def wrapper(*args, **kwargs):
-        """
-        Sync wrapper of mcpt tool `fn` function.
-        Function should return a dict or None.
-
-        :returns: ToolResult object with text-serialized and structured content.
-        """
-        result = fn(*args, **kwargs)
-        if not isinstance(result, dict):
-            result = {"result": result}
-        enc = json.dumps(result, cls=ExtendedEncoder)
-        return ToolResult(content=enc, structured_content=json.loads(enc))
-
-    @wraps(fn)
-    async def async_wrapper(*args, **kwargs):
-        """
-        Async wrapper of mcp tool `fn` function.
-        Function should return a dict or None.
-
-        :returns: ToolResult object with text-serialized and structured content.
-        """
-        result = await fn(*args, **kwargs)
-        if not isinstance(result, dict):
-            result = {"result": result}
-        enc = json.dumps(result, cls=ExtendedEncoder)
-        return ToolResult(content=enc, structured_content=json.loads(enc))
-
-    return async_wrapper if inspect.iscoroutinefunction(fn) else wrapper
+def coerce_rows(rows: List[List[Any]]) -> List[List[Any]]:
+    """Apply `coerce_cell` to every cell in a 2D result set."""
+    return [[coerce_cell(c) for c in row] for row in rows]
 
 
 def inject_limit(query: str, max_rows: int) -> str:

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -13,6 +13,8 @@ from mcp_clickhouse.mcp_server import create_clickhouse_client
 
 from mcp_hydrolix.mcp_server import _build_truncation_response, _resolve_cell_limit
 
+pytestmark = pytest.mark.xfail(reason="pending typed-result refactor", strict=False, run=False)
+
 
 def _assert_structured_matches_content(result, tool_name: str):
     """Assert that structured_content and content[0].text agree."""
@@ -73,7 +75,7 @@ async def test_list_databases(mcp_server, setup_test_database):
     async with Client(mcp_server) as client:
         result = await client.call_tool("list_databases", {})
 
-        databases = result.structured_content["result"]
+        databases = result.structured_content["databases"]
         assert len(databases) >= 1
         assert test_db in databases
         assert "system" in databases  # System database should always exist
@@ -89,7 +91,7 @@ async def test_list_tables_basic(mcp_server, setup_test_database):
     async with Client(mcp_server) as client:
         result = await client.call_tool("list_tables", {"database": test_db})
 
-        tables = result.structured_content["result"]
+        tables = result.structured_content["tables"]
         assert len(tables) >= 1
 
         # Should have exactly 2 tables
@@ -120,7 +122,7 @@ async def test_list_tables_with_like_filter(mcp_server, setup_test_database):
         # Test with LIKE filter
         result = await client.call_tool("list_tables", {"database": test_db, "like": "test_%"})
 
-        tables = result.structured_content["result"]
+        tables = result.structured_content["tables"]
 
         assert len(tables) == 1
         assert tables[0]["name"] == test_table
@@ -134,7 +136,7 @@ async def test_list_tables_with_not_like_filter(mcp_server, setup_test_database)
         # Test with NOT LIKE filter
         result = await client.call_tool("list_tables", {"database": test_db, "not_like": "test_%"})
 
-        tables = result.structured_content["result"]
+        tables = result.structured_content["tables"]
 
         assert len(tables) == 1
         assert tables[0]["name"] == test_table2
@@ -243,7 +245,7 @@ async def test_table_metadata_details(mcp_server, setup_test_database):
     async with Client(mcp_server) as client:
         # First, list tables to discover available tables
         result = await client.call_tool("list_tables", {"database": test_db})
-        tables = result.structured_content["result"]
+        tables = result.structured_content["tables"]
 
         # Verify our test table exists in the list
         test_table_exists = any(t["name"] == test_table for t in tables)
@@ -290,7 +292,7 @@ async def test_system_database_access(mcp_server):
     async with Client(mcp_server) as client:
         # List tables in system database
         result = await client.call_tool("list_tables", {"database": "system"})
-        tables = result.structured_content["result"]
+        tables = result.structured_content["tables"]
 
         # System database should have many tables
         assert len(tables) > 10
@@ -454,7 +456,7 @@ async def test_run_select_query_no_truncation(mcp_server, setup_test_database):
         query = f"SELECT id, name, age FROM {test_db}.{test_table} ORDER BY id"
         result = await client.call_tool("run_select_query", {"query": query, "max_cells": 100})
 
-        query_result = result.data
+        query_result = result.structured_content
         assert query_result["truncated"] is False
         assert query_result["row_count"] == 4
         assert len(query_result["rows"]) == 4
@@ -472,7 +474,7 @@ async def test_run_select_query_no_truncation_at_exact_budget(mcp_server, setup_
         query = f"SELECT id, name, age FROM {test_db}.{test_table} ORDER BY id"
         result = await client.call_tool("run_select_query", {"query": query, "max_cells": 12})
 
-        query_result = result.data
+        query_result = result.structured_content
         assert query_result["truncated"] is False
         assert query_result["row_count"] == 4
 
@@ -487,7 +489,7 @@ async def test_run_select_query_truncation_triggered(mcp_server, setup_test_data
         query = f"SELECT id, name, age, created_at FROM {test_db}.{test_table} ORDER BY id"
         result = await client.call_tool("run_select_query", {"query": query, "max_cells": 4})
 
-        query_result = result.data
+        query_result = result.structured_content
         assert query_result["truncated"] is True
         assert query_result["row_count"] == 1
         assert query_result["total_row_count"] == 4
@@ -507,7 +509,7 @@ async def test_run_select_query_truncation_disabled(mcp_server, setup_test_datab
         query = f"SELECT id, name, age, created_at FROM {test_db}.{test_table} ORDER BY id"
         result = await client.call_tool("run_select_query", {"query": query, "max_cells": 0})
 
-        query_result = result.data
+        query_result = result.structured_content
         assert query_result["truncated"] is False
         assert query_result["row_count"] == 4
         assert len(query_result["rows"]) == 4
@@ -535,7 +537,7 @@ async def test_run_select_query_truncation_max_rows_zero(mcp_server, setup_test_
         query = f"SELECT id, name, age, created_at FROM {test_db}.{test_table} ORDER BY id"
         result = await client.call_tool("run_select_query", {"query": query, "max_cells": 2})
 
-        query_result = result.data
+        query_result = result.structured_content
         assert query_result["truncated"] is True
         assert query_result["row_count"] == 0
         assert len(query_result["rows"]) == 0
@@ -559,7 +561,7 @@ async def test_run_select_query_operator_limit_caps_max_cells(
         query = f"SELECT id, name, age, created_at FROM {test_db}.{test_table} ORDER BY id"
         result = await client.call_tool("run_select_query", {"query": query, "max_cells": 1000})
 
-        query_result = result.data
+        query_result = result.structured_content
         assert query_result["truncated"] is True
         assert query_result["row_count"] == 1
         assert query_result["total_row_count"] == 4
@@ -583,7 +585,7 @@ async def test_run_select_query_operator_limit_overrides_max_cells_zero(
         query = f"SELECT id, name, age, created_at FROM {test_db}.{test_table} ORDER BY id"
         result = await client.call_tool("run_select_query", {"query": query, "max_cells": 0})
 
-        query_result = result.data
+        query_result = result.structured_content
         assert query_result["truncated"] is True
         assert query_result["row_count"] == 1
         assert "administrator" in query_result["message"]
@@ -604,7 +606,7 @@ async def test_run_select_query_operator_limit_caps_default(
         query = f"SELECT id, name, age, created_at FROM {test_db}.{test_table} ORDER BY id"
         result = await client.call_tool("run_select_query", {"query": query})
 
-        query_result = result.data
+        query_result = result.structured_content
         assert query_result["truncated"] is True
         assert query_result["row_count"] == 1
         assert query_result["total_row_count"] == 4
@@ -638,7 +640,7 @@ async def test_run_select_query_env_default_max_cells(monkeypatch, mcp_server, s
         query = f"SELECT id, name, age, created_at FROM {test_db}.{test_table} ORDER BY id"
         result = await client.call_tool("run_select_query", {"query": query})
 
-        query_result = result.data
+        query_result = result.structured_content
         assert query_result["truncated"] is True
         assert query_result["row_count"] == 1  # 4 cells // 4 columns = 1 row
         assert query_result["total_row_count"] == 4

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -13,8 +13,6 @@ from mcp_clickhouse.mcp_server import create_clickhouse_client
 
 from mcp_hydrolix.mcp_server import _build_truncation_response, _resolve_cell_limit
 
-pytestmark = pytest.mark.xfail(reason="pending typed-result refactor", strict=False, run=False)
-
 
 def _assert_structured_matches_content(result, tool_name: str):
     """Assert that structured_content and content[0].text agree."""
@@ -781,38 +779,38 @@ def test_build_truncation_response_basic():
     columns = ["a", "b"]
     rows = [["v1", "v2"]] * 10  # 10 rows, 2 cols = 20 cells; cell_limit=4 -> max_rows=2
     result = _build_truncation_response(columns, rows, cell_limit=4, capped_by_operator=False)
-    assert result["truncated"] is True
-    assert result["row_count"] == 2
-    assert result["total_row_count"] == 10
-    assert len(result["rows"]) == 2
-    assert result["columns"] == columns
-    assert "max_cells" in result["message"]
+    assert result.truncated is True
+    assert result.row_count == 2
+    assert result.total_row_count == 10
+    assert len(result.rows) == 2
+    assert result.columns == columns
+    assert "max_cells" in result.message
 
 
 def test_build_truncation_response_capped_by_operator():
     columns = ["x"]
     rows = [["v"]] * 5
     result = _build_truncation_response(columns, rows, cell_limit=3, capped_by_operator=True)
-    assert "enforced by the server" in result["message"]
-    assert "HYDROLIX_MAX_RESULT_CELLS_LIMIT" in result["message"]
+    assert "enforced by the server" in result.message
+    assert "HYDROLIX_MAX_RESULT_CELLS_LIMIT" in result.message
 
 
 def test_build_truncation_response_not_capped_by_operator():
     columns = ["x"]
     rows = [["v"]] * 5
     result = _build_truncation_response(columns, rows, cell_limit=3, capped_by_operator=False)
-    assert "larger max_cells" in result["message"]
+    assert "larger max_cells" in result.message
 
 
 def test_build_truncation_response_large_result_advisory():
     columns = ["x"]
     rows = [["v"]] * 100_000
     result = _build_truncation_response(columns, rows, cell_limit=50_000, capped_by_operator=False)
-    assert "total_row_count reflects rows fetched" in result["message"]
+    assert "total_row_count reflects rows fetched" in result.message
 
 
 def test_build_truncation_response_no_advisory_below_threshold():
     columns = ["x"]
     rows = [["v"]] * 99_999
     result = _build_truncation_response(columns, rows, cell_limit=50_000, capped_by_operator=False)
-    assert "total_row_count reflects rows fetched" not in result["message"]
+    assert "total_row_count reflects rows fetched" not in result.message

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -10,8 +10,6 @@ from mcp_hydrolix.mcp_server import (
     run_select_query,
 )
 
-pytestmark = pytest.mark.xfail(reason="pending typed-result refactor", strict=False, run=False)
-
 
 class TestHydrolixTools:
     async def test_list_databases(self, setup_tool_test_database):

--- a/tests/test_tool.py
+++ b/tests/test_tool.py
@@ -10,30 +10,30 @@ from mcp_hydrolix.mcp_server import (
     run_select_query,
 )
 
+pytestmark = pytest.mark.xfail(reason="pending typed-result refactor", strict=False, run=False)
+
 
 class TestHydrolixTools:
     async def test_list_databases(self, setup_tool_test_database):
         """Test listing databases."""
         test_db, _ = setup_tool_test_database
         result = await list_databases()
-        assert test_db in result
+        assert test_db in result.databases
 
     async def test_list_tables_without_like(self, setup_tool_test_database):
         """Test listing tables without a 'LIKE' filter."""
         test_db, test_table = setup_tool_test_database
         result = await list_tables(test_db)
-        assert isinstance(result, list)
-        assert len(result) == 1
-        table = result[0]
+        assert len(result.tables) == 1
+        table = result.tables[0]
         assert table.name == test_table
 
     async def test_list_tables_with_like(self, setup_tool_test_database):
         """Test listing tables with a 'LIKE' filter."""
         test_db, test_table = setup_tool_test_database
         result = await list_tables(test_db, like=f"{test_table}%")
-        assert isinstance(result, list)
-        assert len(result) == 1
-        table = result[0]
+        assert len(result.tables) == 1
+        table = result.tables[0]
         assert table.name == test_table
 
     async def test_run_select_query_success(self, setup_tool_test_database):
@@ -41,10 +41,9 @@ class TestHydrolixTools:
         test_db, test_table = setup_tool_test_database
         query = f"SELECT * FROM {test_db}.{test_table}"
         result = await inspect.unwrap(run_select_query)(query)
-        assert isinstance(result, dict)
-        assert len(result["rows"]) == 2
-        assert result["rows"][0][0] == 1
-        assert result["rows"][0][1] == "Alice"
+        assert len(result.rows) == 2
+        assert result.rows[0][0] == 1
+        assert result.rows[0][1] == "Alice"
 
     async def test_run_select_query_failure(self, setup_tool_test_database):
         """Test running a SELECT query with an error."""
@@ -65,10 +64,9 @@ class TestHydrolixTools:
         test_db, test_table = setup_tool_test_database
 
         # First verify the table exists
-        tables = await list_tables(test_db)
-        assert isinstance(tables, list)
-        assert len(tables) == 1
-        assert tables[0].name == test_table
+        result = await list_tables(test_db)
+        assert len(result.tables) == 1
+        assert result.tables[0].name == test_table
 
         # Now get detailed table info including columns
         table_info = await get_table_info(test_db, test_table)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,316 +1,105 @@
-import json
 import ipaddress
 import pytest
-from datetime import datetime, time, timedelta, timezone
+from datetime import date, datetime, time, timedelta, timezone
 from decimal import Decimal
 
-from mcp.types import TextContent
+try:
+    from mcp_hydrolix.utils import coerce_cell, coerce_rows, inject_limit
+except ImportError:  # pending typed-result refactor — symbols arrive in a later commit
+    from mcp_hydrolix.utils import inject_limit
 
-from mcp_hydrolix.utils import ExtendedEncoder, with_serializer, inject_limit
-from fastmcp.tools.tool import ToolResult
+    def coerce_cell(value):  # type: ignore[no-redef]
+        raise NotImplementedError
+
+    def coerce_rows(rows):  # type: ignore[no-redef]
+        raise NotImplementedError
 
 
-class TestExtendedEncoder:
-    """Test suite for ExtendedEncoder class."""
+pytestmark = pytest.mark.xfail(reason="pending typed-result refactor", strict=False, run=False)
 
-    def test_ipv4_address_serialization(self):
-        """Test that IPv4 addresses are serialized to strings."""
-        ip = ipaddress.IPv4Address("192.168.1.1")
-        result = json.dumps({"ip": ip}, cls=ExtendedEncoder)
-        assert result == '{"ip": "192.168.1.1"}'
 
-    def test_datetime_serialization_utc_aware(self):
-        """UTC-aware datetimes (as returned by clickhouse-connect with tz_mode='aware')
-        serialize to the correct UTC epoch regardless of local timezone."""
+class TestCoerceCell:
+    """Coerce a single result cell from clickhouse-connect to a JSON-friendly value."""
+
+    def test_ipv4_address(self):
+        assert coerce_cell(ipaddress.IPv4Address("192.168.1.1")) == "192.168.1.1"
+
+    def test_datetime_utc_aware_returns_epoch(self):
+        """UTC-aware datetimes (clickhouse-connect tz_mode='aware') round-trip to
+        the correct UTC epoch regardless of the local timezone."""
         known_utc_epoch = 1705314645  # 2024-01-15 10:30:45 UTC
         dt = datetime(2024, 1, 15, 10, 30, 45, tzinfo=timezone.utc)
-        result = json.dumps({"ts": dt}, cls=ExtendedEncoder)
-        parsed = json.loads(result)
-        assert parsed["ts"] == known_utc_epoch
+        assert coerce_cell(dt) == known_utc_epoch
 
-    def test_datetime_serialization_non_utc_aware(self):
-        """Non-UTC tz-aware datetimes (e.g. server returning EDT) serialize to the
-        correct epoch.  clickhouse-connect with tz_mode='aware' attaches the server
-        timezone, so 21:00 EDT must produce the same epoch as 01:00 UTC next day."""
+    def test_datetime_non_utc_aware_returns_correct_epoch(self):
+        """A non-UTC tz-aware datetime (e.g. EDT) must produce the same epoch as
+        its UTC equivalent — so 21:00 EDT == 01:00 UTC next day."""
         edt = timezone(timedelta(hours=-4))
         dt = datetime(2024, 1, 15, 21, 0, 0, tzinfo=edt)
-        result = json.dumps({"ts": dt}, cls=ExtendedEncoder)
-        parsed = json.loads(result)
         expected_epoch = datetime(2024, 1, 16, 1, 0, 0, tzinfo=timezone.utc).timestamp()
-        assert parsed["ts"] == expected_epoch
+        assert coerce_cell(dt) == expected_epoch
 
-    def test_datetime_serialization_naive_uses_local_tz(self):
-        """Naive datetimes are interpreted as local time (Python default behavior)."""
+    def test_datetime_naive_uses_local_tz(self):
+        """Naive datetimes follow Python's default behavior: interpreted as local time."""
         dt = datetime(2024, 1, 15, 14, 30, 45)
-        result = json.dumps({"ts": dt}, cls=ExtendedEncoder)
-        parsed = json.loads(result)
-        assert parsed["ts"] == dt.timestamp()
+        assert coerce_cell(dt) == dt.timestamp()
 
-    def test_time_serialization(self):
-        """Test that time objects are converted to seconds."""
-        t = time(14, 30, 45, 123456)
-        result = json.dumps({"time": t}, cls=ExtendedEncoder)
-        expected_time = "14:30:45.123456"
-        assert result == f'{{"time": "{expected_time}"}}'
+    def test_time_full_precision(self):
+        assert coerce_cell(time(14, 30, 45, 123456)) == "14:30:45.123456"
 
-    def test_time_serialization_midnight(self):
-        """Test time serialization at midnight (edge case)."""
-        t = time(0, 0, 0, 0)
-        result = json.dumps({"time": t}, cls=ExtendedEncoder)
-        assert result == '{"time": "00:00:00"}'
+    def test_time_midnight(self):
+        assert coerce_cell(time(0, 0, 0, 0)) == "00:00:00"
 
-    def test_time_serialization_end_of_day(self):
-        """Test time serialization at end of day (edge case)."""
-        t = time(23, 59, 59, 999999)
-        result = json.dumps({"time": t}, cls=ExtendedEncoder)
-        assert result == '{"time": "23:59:59.999999"}'
+    def test_time_end_of_day(self):
+        assert coerce_cell(time(23, 59, 59, 999999)) == "23:59:59.999999"
 
-    def test_bytes_serialization(self):
-        """Test that bytes are decoded to strings."""
-        data = b"hello world"
-        result = json.dumps({"data": data}, cls=ExtendedEncoder)
-        assert result == '{"data": "hello world"}'
+    def test_date(self):
+        assert coerce_cell(date(2024, 1, 15)) == "2024-01-15"
 
-    def test_bytes_serialization_utf8(self):
-        """Test bytes serialization with UTF-8 characters."""
-        data = "hello 世界".encode("utf-8")
-        result = json.dumps({"data": data}, cls=ExtendedEncoder)
-        assert result == '{"data": "hello 世界"}'.encode("unicode-escape").decode("utf-8")
+    def test_bytes_ascii(self):
+        assert coerce_cell(b"hello world") == "hello world"
 
-    def test_decimal_serialization(self):
-        """Test that Decimal objects are converted to strings."""
-        dec = Decimal("123.456")
-        result = json.dumps({"amount": dec}, cls=ExtendedEncoder)
-        assert result == '{"amount": "123.456"}'
+    def test_bytes_utf8(self):
+        assert coerce_cell("hello 世界".encode("utf-8")) == "hello 世界"
 
-    def test_decimal_serialization_precision(self):
-        """Test Decimal serialization preserves precision."""
-        dec = Decimal("0.123456789012345678901234567890")
-        result = json.dumps({"value": dec}, cls=ExtendedEncoder)
-        assert result == '{"value": "0.123456789012345678901234567890"}'
+    def test_decimal_basic(self):
+        assert coerce_cell(Decimal("123.456")) == "123.456"
 
-    def test_combined_types_serialization(self):
-        """Test serialization of multiple custom types together."""
-        data = {
-            "ip": ipaddress.IPv4Address("10.0.0.1"),
-            "time": time(12, 0, 0),
-            "data": b"test",
-            "amount": Decimal("99.99"),
-        }
-        result = json.dumps(data, cls=ExtendedEncoder)
-        parsed = json.loads(result)
+    def test_decimal_precision_preserved(self):
+        assert (
+            coerce_cell(Decimal("0.123456789012345678901234567890"))
+            == "0.123456789012345678901234567890"
+        )
 
-        assert parsed["ip"] == "10.0.0.1"
-        assert parsed["time"] == "12:00:00"
-        assert parsed["data"] == "test"
-        assert parsed["amount"] == "99.99"
+    @pytest.mark.parametrize(
+        "value",
+        ["test", 42, 3.14, True, False, None, [1, 2, 3], {"k": "v"}],
+    )
+    def test_passthrough_for_native_json_types(self, value):
+        """Standard JSON-friendly types — including None — pass through unchanged.
 
-    def test_nested_serialization(self):
-        """Test serialization of nested structures."""
-        data = {
-            "users": [
-                {"ip": ipaddress.IPv4Address("192.168.1.100"), "balance": Decimal("1000.50")},
-                {"ip": ipaddress.IPv4Address("192.168.1.101"), "balance": Decimal("2000.75")},
-            ]
-        }
-        result = json.dumps(data, cls=ExtendedEncoder)
-        parsed = json.loads(result)
-
-        assert parsed["users"][0]["ip"] == "192.168.1.100"
-        assert parsed["users"][0]["balance"] == "1000.50"
-        assert parsed["users"][1]["ip"] == "192.168.1.101"
-        assert parsed["users"][1]["balance"] == "2000.75"
-
-    def test_date_serialization(self):
-        """Test that date objects (not datetime) are serialized via isoformat."""
-        from datetime import date
-
-        d = date(2024, 1, 15)
-        result = json.dumps({"d": d}, cls=ExtendedEncoder)
-        assert result == '{"d": "2024-01-15"}'
-
-    def test_standard_types_unchanged(self):
-        """Test that standard JSON types are serialized normally."""
-        data = {
-            "string": "test",
-            "number": 42,
-            "float": 3.14,
-            "boolean": True,
-            "null": None,
-            "list": [1, 2, 3],
-            "dict": {"key": "value"},
-        }
-        result = json.dumps(data, cls=ExtendedEncoder)
-        parsed = json.loads(result)
-        assert parsed == data
+        None is data when it appears in a query result row (the user's SELECT may
+        return SQL NULLs) and must not be dropped at the cell level.
+        """
+        assert coerce_cell(value) == value
 
 
-class TestWithSerializerDecorator:
-    """Test suite for with_serializer decorator."""
+class TestCoerceRows:
+    def test_walks_2d_grid(self):
+        rows = [
+            [ipaddress.IPv4Address("10.0.0.1"), Decimal("1.5"), None],
+            [ipaddress.IPv4Address("10.0.0.2"), Decimal("2.5"), 42],
+        ]
+        assert coerce_rows(rows) == [
+            ["10.0.0.1", "1.5", None],
+            ["10.0.0.2", "2.5", 42],
+        ]
 
-    def test_sync_function_basic(self):
-        """Test decorator works with synchronous functions."""
+    def test_empty_rows(self):
+        assert coerce_rows([]) == []
 
-        @with_serializer
-        def mock_tool():
-            return {"result": "success"}
-
-        result = mock_tool()
-
-        assert isinstance(result, ToolResult)
-        assert result.content == [TextContent(type="text", text='{"result": "success"}')]
-        assert result.structured_content == {"result": "success"}
-
-    def test_sync_function_with_args(self):
-        """Test decorator works with function arguments."""
-
-        @with_serializer
-        def mock_tool(arg1, arg2):
-            return {"arg1": arg1, "arg2": arg2}
-
-        result = mock_tool("value1", "value2")
-
-        assert isinstance(result, ToolResult)
-        assert result.structured_content == {"arg1": "value1", "arg2": "value2"}
-
-    def test_sync_function_with_kwargs(self):
-        """Test decorator works with keyword arguments."""
-
-        @with_serializer
-        def mock_tool(name, age=0):
-            return {"name": name, "age": age}
-
-        result = mock_tool(name="Alice", age=30)
-
-        assert isinstance(result, ToolResult)
-        assert result.structured_content == {"name": "Alice", "age": 30}
-
-    async def test_async_function_basic(self):
-        """Test decorator works with async functions."""
-
-        @with_serializer
-        async def mock_async_tool():
-            return {"result": "async success"}
-
-        result = await mock_async_tool()
-
-        assert isinstance(result, ToolResult)
-        assert result.content == [TextContent(type="text", text='{"result": "async success"}')]
-        assert result.structured_content == {"result": "async success"}
-
-    async def test_async_function_with_args(self):
-        """Test decorator works with async function arguments."""
-
-        @with_serializer
-        async def mock_async_tool(x, y):
-            return {"sum": x + y}
-
-        result = await mock_async_tool(5, 10)
-
-        assert isinstance(result, ToolResult)
-        assert result.structured_content == {"sum": 15}
-
-    def test_custom_types_serialization(self):
-        """Test decorator properly serializes custom types."""
-
-        @with_serializer
-        def mock_tool():
-            return {
-                "ip": ipaddress.IPv4Address("172.16.0.1"),
-                "amount": Decimal("500.00"),
-                "data": b"encoded",
-            }
-
-        result = mock_tool()
-
-        assert isinstance(result, ToolResult)
-        parsed = result.structured_content
-        assert parsed["ip"] == "172.16.0.1"
-        assert parsed["amount"] == "500.00"
-        assert parsed["data"] == "encoded"
-
-    async def test_async_custom_types_serialization(self):
-        """Test decorator serializes custom types in async functions."""
-
-        @with_serializer
-        async def mock_async_tool():
-            return {"time": time(10, 30, 0), "decimal": Decimal("123.45")}
-
-        result = await mock_async_tool()
-
-        assert isinstance(result, ToolResult)
-        parsed = result.structured_content
-        assert parsed["time"] == "10:30:00"
-        assert parsed["decimal"] == "123.45"
-
-    def test_content_structured_content_match(self):
-        """Test that content and structured_content are consistent."""
-
-        @with_serializer
-        def mock_tool():
-            return {"key": "value", "number": 42}
-
-        result: ToolResult = mock_tool()
-
-        # Parse the content string and verify it matches structured_content
-        parsed_content = json.loads(result.content[0].text)
-        assert parsed_content == result.structured_content
-
-    def test_complex_nested_structure(self):
-        """Test decorator handles complex nested structures."""
-
-        @with_serializer
-        def mock_tool():
-            return {
-                "users": [
-                    {
-                        "id": 1,
-                        "ip": ipaddress.IPv4Address("192.168.1.1"),
-                        "balance": Decimal("1000.50"),
-                    },
-                    {
-                        "id": 2,
-                        "ip": ipaddress.IPv4Address("192.168.1.2"),
-                        "balance": Decimal("2000.75"),
-                    },
-                ],
-                "metadata": {"timestamp": time(14, 30, 0), "data": b"metadata"},
-            }
-
-        result = mock_tool()
-
-        assert isinstance(result, ToolResult)
-        parsed = result.structured_content
-        assert len(parsed["users"]) == 2
-        assert parsed["users"][0]["ip"] == "192.168.1.1"
-        assert parsed["users"][0]["balance"] == "1000.50"
-        assert parsed["metadata"]["data"] == "metadata"
-
-    def test_empty_result(self):
-        """Test decorator handles empty results."""
-
-        @with_serializer
-        def mock_tool():
-            return {}
-
-        result = mock_tool()
-
-        assert isinstance(result, ToolResult)
-        assert result.content == [TextContent(type="text", text="{}")]
-        assert result.structured_content == {}
-
-    def test_list_result(self):
-        """Test decorator handles list results."""
-
-        @with_serializer
-        def mock_tool():
-            return [1, 2, 3, 4, 5]
-
-        result = mock_tool()
-
-        assert isinstance(result, ToolResult)
-        assert result.content == [TextContent(type="text", text='{"result": [1, 2, 3, 4, 5]}')]
-        assert result.structured_content == {"result": [1, 2, 3, 4, 5]}
+    def test_empty_row(self):
+        assert coerce_rows([[]]) == [[]]
 
 
 class TestClientTimezoneConfig:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,19 +3,7 @@ import pytest
 from datetime import date, datetime, time, timedelta, timezone
 from decimal import Decimal
 
-try:
-    from mcp_hydrolix.utils import coerce_cell, coerce_rows, inject_limit
-except ImportError:  # pending typed-result refactor — symbols arrive in a later commit
-    from mcp_hydrolix.utils import inject_limit
-
-    def coerce_cell(value):  # type: ignore[no-redef]
-        raise NotImplementedError
-
-    def coerce_rows(rows):  # type: ignore[no-redef]
-        raise NotImplementedError
-
-
-pytestmark = pytest.mark.xfail(reason="pending typed-result refactor", strict=False, run=False)
+from mcp_hydrolix.utils import coerce_cell, coerce_rows, inject_limit
 
 
 class TestCoerceCell:


### PR DESCRIPTION
What does this PR do?
-----------------------

Refactors how MCP tool results are produced and serialized so that fastmcp can emit accurate JSON-Schema for clients while keeping wire payloads token-minimal.

- **Tagged discriminated `ColumnType`** — Promoted `Column`, `AliasColumn`, `AggregateColumn`, and `SummaryColumn` from plain `@dataclass` to a tagged-union (via `column_category`) of `pydantic_dataclass`. Token-saving "drop None/empty" behavior is preserved per-column via a small `@model_serializer(mode="wrap")` on each model
- **Typed result models for `list_databases`, `list_tables`, and `run_select_query`** — Adds `DatabaseList`, `TableList`, and `RunSelectQueryResult` Pydantic dataclasses to replace fastmcp's generic `{"result": [...]}` wrapper with self-describing `{"databases": [...]}` / `{"tables": [...]}` shapes, and give `run_select_query` a stable typed schema.
- **Native fastmcp serialization** — Drops the `with_serializer` decorator and `ExtendedEncoder` JSON encoder. fastmcp now serializes the typed results natively. ClickHouse-specific value coercions (`datetime → epoch`, `IPv4 → str`, `Decimal → str`, `bytes → utf-8 decode`, `date/time → isoformat`) are now in an explicitly-invoked helper
- No call-site changes

Does this PR meet the acceptance criteria?
--------------------------------------------

* [x] Documentation created/updated
* [x] Tests added for this feature/bug
* [ ] Does this change request have any security impacts?

Release Notes
---------------------------------------------------

* Major changes:
    *
* Minor changes:
    * MCP schemas now generate more informative JSON schemas, making for more ergonomic usage with certain MCP clients (eg fastMCP)
* Bugfixes:
    *
* Issues Closed:
    *
* Security impacts identified:
    * None.

Testing
--------------------------------------------

- Unit and integration tests pass locally via `uv run pytest`. No additional testing required.