### PR TITLE
Fix PR template to say "PR"

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,7 @@
-What does this MR do?
+What does this PR do?
 -----------------------
 
-Does this MR meet the acceptance criteria?
+Does this PR meet the acceptance criteria?
 --------------------------------------------
 
 * [ ] Documentation created/updated


### PR DESCRIPTION
This is a GitHub repository — pull requests are PRs, not MRs.