### PR TITLE
[IL][HDX-11432] Splitting health check endpoint into liveness and readiness endpoints

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ EXPOSE 8000
 
 # Got a health check too
 HEALTHCHECK --interval=30s --timeout=30s --start-period=5s --retries=3 \
-  CMD [ "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:8000/health" ]
+  CMD [ "wget", "--no-verbose", "--tries=1", "--spider", "http://127.0.0.1:8000/healthz" ]
 
 RUN addgroup -g 1000 -S appgroup && \
   adduser -u 1000 -S appuser -G appgroup -h /app -s /sbin/nologin

--- a/mcp_hydrolix/mcp_server.py
+++ b/mcp_hydrolix/mcp_server.py
@@ -2,6 +2,7 @@ import asyncio
 import base64
 import logging
 import time
+from pathlib import Path
 from typing import (
     Any,
     Dict,
@@ -270,6 +271,27 @@ async def execute_cmd(query: str):
         metrics.METRICS.query_duration_seconds.observe(time.perf_counter() - start)
 
 
+# only relevant when running in a Hydrolix cluster
+_K8S_SERVICE_TOKEN_DIR = Path("/var/run/secrets/service-tokens")
+_K8S_SERVICE_TOKEN_NAMES = ("SA_READONLY_TOKEN", "SA_ADMIN_TOKEN")
+
+
+def _load_k8s_service_credential() -> Optional[HydrolixCredential]:
+    """Load a service account credential from the k8s secret mount, if available.
+
+    Tries SA_READONLY_TOKEN first, then SA_ADMIN_TOKEN. Returns None if neither
+    can be read or parsed (e.g. running outside k8s).
+    """
+    for name in _K8S_SERVICE_TOKEN_NAMES:
+        try:
+            token = (_K8S_SERVICE_TOKEN_DIR / name).read_text().strip()
+            if token:
+                return ServiceAccountToken(token, None)
+        except Exception:
+            continue
+    return None
+
+
 @mcp.custom_route("/healthz", methods=["GET"])
 async def liveness_check(request: Request) -> PlainTextResponse:
     """Liveness endpoint: returns 200 if the process is alive."""
@@ -279,10 +301,9 @@ async def liveness_check(request: Request) -> PlainTextResponse:
 @mcp.custom_route("/health", methods=["GET"])
 async def readiness_check(request: Request) -> PlainTextResponse:
     """Readiness endpoint: returns 200 only when able to connect to Hydrolix."""
+    credential = get_request_credential() or _load_k8s_service_credential()
     try:
-        async with await create_hydrolix_client(
-            client_shared_pool, get_request_credential()
-        ) as client:
+        async with await create_hydrolix_client(client_shared_pool, credential) as client:
             version = client.client.server_version
         return PlainTextResponse(f"OK - Connected to Hydrolix compatible with ClickHouse {version}")
     except Exception as e:

--- a/mcp_hydrolix/mcp_server.py
+++ b/mcp_hydrolix/mcp_server.py
@@ -270,21 +270,22 @@ async def execute_cmd(query: str):
         metrics.METRICS.query_duration_seconds.observe(time.perf_counter() - start)
 
 
-@mcp.custom_route("/health", methods=["GET"])
-async def health_check(request: Request) -> PlainTextResponse:
-    """Health check endpoint for monitoring server status.
+@mcp.custom_route("/healthz", methods=["GET"])
+async def liveness_check(request: Request) -> PlainTextResponse:
+    """Liveness endpoint: returns 200 if the process is alive."""
+    return PlainTextResponse("OK")
 
-    Returns OK if the server is running and can connect to Hydrolix.
-    """
+
+@mcp.custom_route("/health", methods=["GET"])
+async def readiness_check(request: Request) -> PlainTextResponse:
+    """Readiness endpoint: returns 200 only when able to connect to Hydrolix."""
     try:
-        # Try to create a client connection to verify query-head connectivity
         async with await create_hydrolix_client(
             client_shared_pool, get_request_credential()
         ) as client:
             version = client.client.server_version
         return PlainTextResponse(f"OK - Connected to Hydrolix compatible with ClickHouse {version}")
     except Exception as e:
-        # Return 503 Service Unavailable if we can't connect to Hydrolix
         return PlainTextResponse(f"ERROR - Cannot connect to Hydrolix: {str(e)}", status_code=503)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ license-files = ["LICENSE"]
 requires-python = ">=3.13"
 dependencies = [
     "fastmcp>=3.0.2,<3.3",
-    "python-dotenv>=1.1,<1.2",
+    "python-dotenv>=1.1,<1.3",
     "clickhouse-connect>=0.15,<0.16",
     "truststore>=0.10",
     "uvicorn[standard]>=0.34,<1.0",

--- a/uv.lock
+++ b/uv.lock
@@ -54,14 +54,14 @@ wheels = [
 
 [[package]]
 name = "authlib"
-version = "1.6.9"
+version = "1.6.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/af/98/00d3dd826d46959ad8e32af2dbb2398868fd9fd0683c26e56d0789bd0e68/authlib-1.6.9.tar.gz", hash = "sha256:d8f2421e7e5980cc1ddb4e32d3f5fa659cfaf60d8eaf3281ebed192e4ab74f04", size = 165134, upload-time = "2026-03-02T07:44:01.998Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/28/10/b325d58ffe86815b399334a101e63bc6fa4e1953921cb23703b48a0a0220/authlib-1.6.11.tar.gz", hash = "sha256:64db35b9b01aeccb4715a6c9a6613a06f2bd7be2ab9d2eb89edd1dfc7580a38f", size = 165359, upload-time = "2026-04-16T07:22:50.279Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/53/23/b65f568ed0c22f1efacb744d2db1a33c8068f384b8c9b482b52ebdbc3ef6/authlib-1.6.9-py2.py3-none-any.whl", hash = "sha256:f08b4c14e08f0861dc18a32357b33fbcfd2ea86cfe3fe149484b4d764c4a0ac3", size = 244197, upload-time = "2026-03-02T07:44:00.307Z" },
+    { url = "https://files.pythonhosted.org/packages/57/2f/55fca558f925a51db046e5b929deb317ddb05afed74b22d89f4eca578980/authlib-1.6.11-py2.py3-none-any.whl", hash = "sha256:c8687a9a26451c51a34a06fa17bb97cb15bba46a6a626755e2d7f50da8bff3e3", size = 244469, upload-time = "2026-04-16T07:22:48.413Z" },
 ]
 
 [[package]]
@@ -753,7 +753,7 @@ requires-dist = [
     { name = "pyjwt", specifier = ">=2.10,<2.13" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-asyncio", marker = "extra == 'dev'" },
-    { name = "python-dotenv", specifier = ">=1.1,<1.2" },
+    { name = "python-dotenv", specifier = ">=1.1,<1.3" },
     { name = "ruff", marker = "extra == 'dev'" },
     { name = "sqlglot", specifier = ">=26.0,<27.0" },
     { name = "truststore", specifier = ">=0.10" },
@@ -1159,7 +1159,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.2"
+version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1168,9 +1168,9 @@ dependencies = [
     { name = "pluggy" },
     { name = "pygments" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
 ]
 
 [[package]]
@@ -1212,11 +1212,11 @@ wheels = [
 
 [[package]]
 name = "python-dotenv"
-version = "1.1.1"
+version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f6/b0/4bc07ccd3572a2f9df7e6782f52b0c6c90dcbb803ac4a167702d7d0dfe1e/python_dotenv-1.1.1.tar.gz", hash = "sha256:a8a6399716257f45be6a007360200409fce5cda2661e3dec71d23dc15f6189ab", size = 41978, upload-time = "2025-06-24T04:21:07.341Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/ed/539768cf28c661b5b068d66d96a2f155c4971a5d55684a514c1a0e0dec2f/python_dotenv-1.1.1-py3-none-any.whl", hash = "sha256:31f23644fe2602f88ff55e1f5c79ba497e01224ee7737937930c448e4d0e24dc", size = 20556, upload-time = "2025-06-24T04:21:06.073Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1221,11 +1221,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.22"
+version = "0.0.27"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/69/9b/f23807317a113dc36e74e75eb265a02dd1a4d9082abc3c1064acd22997c4/python_multipart-0.0.27.tar.gz", hash = "sha256:9870a6a8c5a20a5bf4f07c017bd1489006ff8836cff097b6933355ee2b49b602", size = 44043, upload-time = "2026-04-27T10:51:26.649Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
+    { url = "https://files.pythonhosted.org/packages/99/78/4126abcbdbd3c559d43e0db7f7b9173fc6befe45d39a2856cc0b8ec2a5a6/python_multipart-0.0.27-py3-none-any.whl", hash = "sha256:6fccfad17a27334bd0193681b369f476eda3409f17381a2d65aa7df3f7275645", size = 29254, upload-time = "2026-04-27T10:51:24.997Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
What does this PR do?
-----------------------

Kubernetes liveness and readiness probes serve different purposes. A single `/health` endpoint can't serve both. Using it for liveness means a non-200 response restarts a pod that would recover on its own, while falling back to a TCP socket liveness probe is fragile since a port being open does not necessarily mean the HTTP server is functional and creates a "live but not ready" trap where a permanently degraded pod is never restarted. Splitting into `/healthz` (liveness: 200 if the process is alive) and `/health` (readiness: 200 if ready to serve) gives Kubernetes the two independent signals it needs.

Because the readiness endpoint needs credentials to connect to the queryhead, I'm having it read the service account tokens which is mounted as a secret volume.

Does this PR meet the acceptance criteria?
--------------------------------------------

* [x] Documentation created/updated
* [] Tests added for this feature/bug
* [N] Does this change request have any security impacts?

Release Notes
---------------------------------------------------

* Major changes:
    *
* Minor changes:
    * splits the health check endpoint to two endpoints: liveness and readiness check endponits
* Bugfixes:
    *
* Issues Closed:
    *
* Security impacts identified:
    *

Testing
--------------------------------------------
