### PR TITLE
[IL][HDX-11151] Log service account ID per authenticated MCP request

### DIFF
--- a/mcp_hydrolix/auth/__init__.py
+++ b/mcp_hydrolix/auth/__init__.py
@@ -4,6 +4,11 @@ This package contains authentication-related types used to define hydrolix auth
 in terms of FastMCP infrastructure
 """
 
+from typing import Optional
+
+from fastmcp.server.dependencies import get_access_token
+from jwt import DecodeError
+
 from mcp_hydrolix.auth.credentials import (
     HydrolixCredential,
     ServiceAccountToken,
@@ -17,6 +22,32 @@ from mcp_hydrolix.auth.mcp_providers import (
     HydrolixCredentialChain,
 )
 
+
+def get_request_credential() -> Optional[HydrolixCredential]:
+    """Resolve the per-request Hydrolix credential from the FastMCP auth context.
+
+    Returns the credential decoded from the per-request access token (HTTP /
+    SSE transports with a Bearer or ``?token=`` param), or ``None`` when there
+    is no per-request auth context (stdio transport, or HTTP without a
+    bearer). Callers typically pass the result to
+    ``HydrolixConfig.creds_with(...)`` to fold in the env-supplied default.
+
+    Raises ``ValueError`` if a token is present but invalid or of an
+    unexpected access-token type.
+    """
+    if (token := get_access_token()) is not None:
+        if isinstance(token, AccessToken):
+            try:
+                return token.as_credential()
+            except DecodeError:
+                raise ValueError("The provided access token is invalid.")
+        else:
+            raise ValueError(
+                "Found non-hydrolix access token on request -- this should be impossible!"
+            )
+    return None
+
+
 __all__ = [
     "HydrolixCredential",
     "ServiceAccountToken",
@@ -26,4 +57,5 @@ __all__ = [
     "GetParamAuthBackend",
     "HydrolixCredentialChain",
     "TOKEN_PARAM",
+    "get_request_credential",
 ]

--- a/mcp_hydrolix/log/log.py
+++ b/mcp_hydrolix/log/log.py
@@ -7,6 +7,11 @@ from pathlib import Path
 import yaml
 
 
+# Standard LogRecord attribute names — anything else on the record came from
+# a caller's ``extra={...}`` kwarg and should be surfaced in the JSON envelope.
+_STANDARD_LOGRECORD_ATTRS = frozenset(logging.LogRecord("", 0, "", 0, "", None, None).__dict__)
+
+
 class JsonFormatter(logging.Formatter):
     """
     Custom formatter to output logs in JSON format.
@@ -28,6 +33,13 @@ class JsonFormatter(logging.Formatter):
 
         if record.exc_info:
             log_record["exception"] = self.formatException(record.exc_info)
+
+        # ``setdefault`` keeps envelope fields (level, timestamp, ...) from
+        # being clobbered if a caller accidentally passes a same-named extra.
+        for key, value in record.__dict__.items():
+            if key in _STANDARD_LOGRECORD_ATTRS:
+                continue
+            log_record.setdefault(key, value)
 
         return json.dumps(log_record)
 

--- a/mcp_hydrolix/mcp_server.py
+++ b/mcp_hydrolix/mcp_server.py
@@ -23,22 +23,20 @@ from clickhouse_connect.driver.binding import format_query_value
 from dotenv import load_dotenv
 from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
-from fastmcp.server.dependencies import get_access_token
 from fastmcp.server.middleware import Middleware, MiddlewareContext
-from jwt import DecodeError
 from mcp.types import ToolAnnotations
 from starlette.requests import Request
 from starlette.responses import PlainTextResponse, Response
 
 from mcp_hydrolix import metrics
 from mcp_hydrolix.auth import (
-    AccessToken,
     HydrolixCredential,
     HydrolixCredentialChain,
     ServiceAccountToken,
     UsernamePassword,
+    get_request_credential,
 )
-from mcp_hydrolix.sa_attribution import SAAttributionMiddleware
+from mcp_hydrolix.sa_attribution import ServiceAccountAttributionMiddleware
 from mcp_hydrolix.mcp_env import HydrolixConfig, get_config
 from mcp_hydrolix.column_analysis import (
     _enrich_column_metadata,
@@ -68,20 +66,6 @@ mcp = FastMCP(
     name=MCP_SERVER_NAME,
     auth=HydrolixCredentialChain(None),
 )
-
-
-def get_request_credential() -> Optional[HydrolixCredential]:
-    if (token := get_access_token()) is not None:
-        if isinstance(token, AccessToken):
-            try:
-                return token.as_credential()
-            except DecodeError:
-                raise ValueError("The provided access token is invalid.")
-        else:
-            raise ValueError(
-                "Found non-hydrolix access token on request -- this should be impossible!"
-            )
-    return None
 
 
 async def create_hydrolix_client(pool_mgr, request_credential: Optional[HydrolixCredential]):
@@ -344,7 +328,7 @@ if HYDROLIX_CONFIG.metrics_enabled:
 
 # Per-request SA attribution logging (HDX-11151). Unconditional; see
 # mcp_hydrolix.sa_attribution for the temporary-stopgap rationale.
-mcp.add_middleware(SAAttributionMiddleware())
+mcp.add_middleware(ServiceAccountAttributionMiddleware())
 
 
 async def _query_targets_summary_table(query: str) -> bool:

--- a/mcp_hydrolix/mcp_server.py
+++ b/mcp_hydrolix/mcp_server.py
@@ -38,6 +38,7 @@ from mcp_hydrolix.auth import (
     ServiceAccountToken,
     UsernamePassword,
 )
+from mcp_hydrolix.sa_attribution import SAAttributionMiddleware
 from mcp_hydrolix.mcp_env import HydrolixConfig, get_config
 from mcp_hydrolix.column_analysis import (
     _enrich_column_metadata,
@@ -339,6 +340,11 @@ if HYDROLIX_CONFIG.metrics_enabled:
                 metrics.METRICS.active_requests.dec()
 
     mcp.add_middleware(MetricsMiddleware())
+
+
+# Per-request SA attribution logging (HDX-11151). Unconditional; see
+# mcp_hydrolix.sa_attribution for the temporary-stopgap rationale.
+mcp.add_middleware(SAAttributionMiddleware())
 
 
 async def _query_targets_summary_table(query: str) -> bool:

--- a/mcp_hydrolix/sa_attribution.py
+++ b/mcp_hydrolix/sa_attribution.py
@@ -13,9 +13,10 @@ the JWT (``iss``, ``aud``, ``sub``, ``iat``, ``exp``, ``jti``) nor the
 from the MCP side. It would land here too if turbine grows a ``created_by``
 field and bakes it into the JWT claim set.
 
-OpenSpec landed in the repo (#102) after this middleware was implemented; the
-design here is captured in the PR description rather than as an OpenSpec
-proposal/spec. Future features should use the OpenSpec workflow.
+This middleware predates the OpenSpec workflow now in the repo (introduced
+in #102, refined in #104 and #106). Its design lives in the PR description
+rather than as an OpenSpec proposal/spec. Future features should use that
+workflow.
 """
 
 from __future__ import annotations
@@ -23,17 +24,16 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from fastmcp.server.dependencies import get_access_token
 from fastmcp.server.middleware import Middleware, MiddlewareContext
 
-from mcp_hydrolix.auth import AccessToken, ServiceAccountToken
+from mcp_hydrolix.auth import ServiceAccountToken, get_request_credential
 from mcp_hydrolix.mcp_env import get_config
 
 
 logger = logging.getLogger(__name__)
 
 
-class SAAttributionMiddleware(Middleware):
+class ServiceAccountAttributionMiddleware(Middleware):
     """Log one structured line per authenticated MCP request.
 
     The log line carries ``service_account_id`` (and ``tool_name`` for
@@ -48,25 +48,21 @@ class SAAttributionMiddleware(Middleware):
     """
 
     async def on_request(self, context: MiddlewareContext, call_next) -> Any:
+        # Resolve the effective credential (per-request bearer first, env
+        # default fallback). ``creds_with`` raises ValueError when neither is
+        # available; in that case there's nothing to attribute, so skip
+        # logging entirely.
         try:
-            request_token = get_access_token()
-            credential = None
-            if isinstance(request_token, AccessToken):
-                credential = request_token.as_credential()
-            else:
-                # No per-request auth context (stdio, or HTTP without a bearer).
-                # Fall back to the env-configured default credential.
-                try:
-                    credential = get_config().creds_with(None)
-                except ValueError:
-                    # No default credential configured either — nothing to log.
-                    pass
+            credential = get_config().creds_with(get_request_credential())
+        except ValueError:
+            return await call_next(context)
 
-            # ``credential`` may be ``HydrolixCredential`` (abstract); only the
-            # SA subtype carries ``service_account_id``. Guard rather than rely
-            # on the broad except below so a non-SA credential (e.g.
-            # UsernamePassword) skips cleanly without a misleading "logging
-            # failed" debug line.
+        # Best-effort logging. ``credential`` may be ``HydrolixCredential``
+        # (abstract); only the SA subtype carries ``service_account_id``, so
+        # non-SA credentials (e.g. UsernamePassword) skip cleanly via the
+        # isinstance guard. The broad ``except`` is a safety net so an
+        # unexpected logging-path failure can't turn into a request error.
+        try:
             if isinstance(credential, ServiceAccountToken):
                 fields: dict[str, Any] = {
                     "service_account_id": credential.service_account_id,
@@ -77,8 +73,6 @@ class SAAttributionMiddleware(Middleware):
                         fields["tool_name"] = tool_name
                 logger.info("mcp_request", extra=fields)
         except Exception:
-            # Attribution is best-effort; never let a malformed token or other
-            # logging-path failure turn into a request error.
             logger.debug("SA attribution logging failed", exc_info=True)
 
         return await call_next(context)

--- a/mcp_hydrolix/sa_attribution.py
+++ b/mcp_hydrolix/sa_attribution.py
@@ -1,0 +1,67 @@
+"""Per-request service-account attribution logging (HDX-11151).
+
+Emits one structured INFO log line per authenticated MCP request so log
+aggregators can tie queries back to a specific service account.
+
+This is a temporary stopgap. The fuller picture lives on query-head, which
+will eventually log service-account queries directly; once that ships, this
+middleware can be retired. See HDX-11151.
+
+NOTE: the ticket also asks for the *creator's* email per request. Today neither
+the JWT (``iss``, ``aud``, ``sub``, ``iat``, ``exp``, ``jti``) nor the
+``ServiceAccount`` record in turbine carries that field, so it can't be logged
+from the MCP side. It would land here too if turbine grows a ``created_by``
+field and bakes it into the JWT claim set.
+
+OpenSpec landed in the repo (#102) after this middleware was implemented; the
+design here is captured in the PR description rather than as an OpenSpec
+proposal/spec. Future features should use the OpenSpec workflow.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastmcp.server.dependencies import get_access_token
+from fastmcp.server.middleware import Middleware, MiddlewareContext
+
+from mcp_hydrolix.auth import AccessToken, ServiceAccountToken
+
+
+logger = logging.getLogger(__name__)
+
+
+class SAAttributionMiddleware(Middleware):
+    """Log one structured line per authenticated MCP request.
+
+    The log line carries ``service_account_id`` (and ``tool_name`` for
+    ``tools/call``) as top-level JSON fields via the ``JsonFormatter``
+    extra-surfacing pass, so log processors can index/filter on them directly.
+    """
+
+    async def on_request(self, context: MiddlewareContext, call_next) -> Any:
+        try:
+            token = get_access_token()
+            if isinstance(token, AccessToken):
+                credential = token.as_credential()
+                # ``as_credential()`` is typed to return the abstract
+                # ``HydrolixCredential``; only the SA subtype carries
+                # ``service_account_id``. Guard rather than rely on the broad
+                # except below, so a non-SA credential skips cleanly without
+                # the misleading "logging failed" debug line.
+                if isinstance(credential, ServiceAccountToken):
+                    fields: dict[str, Any] = {
+                        "service_account_id": credential.service_account_id,
+                    }
+                    if context.method == "tools/call":
+                        tool_name = getattr(context.message, "name", None)
+                        if tool_name is not None:
+                            fields["tool_name"] = tool_name
+                    logger.info("mcp_request", extra=fields)
+        except Exception:
+            # Attribution is best-effort; never let a malformed token or other
+            # logging-path failure turn into a request error.
+            logger.debug("SA attribution logging failed", exc_info=True)
+
+        return await call_next(context)

--- a/mcp_hydrolix/sa_attribution.py
+++ b/mcp_hydrolix/sa_attribution.py
@@ -27,6 +27,7 @@ from fastmcp.server.dependencies import get_access_token
 from fastmcp.server.middleware import Middleware, MiddlewareContext
 
 from mcp_hydrolix.auth import AccessToken, ServiceAccountToken
+from mcp_hydrolix.mcp_env import get_config
 
 
 logger = logging.getLogger(__name__)
@@ -38,27 +39,43 @@ class SAAttributionMiddleware(Middleware):
     The log line carries ``service_account_id`` (and ``tool_name`` for
     ``tools/call``) as top-level JSON fields via the ``JsonFormatter``
     extra-surfacing pass, so log processors can index/filter on them directly.
+
+    Resolves the effective credential the same way ``create_hydrolix_client``
+    does: a per-request bearer token (HTTP transport) takes precedence; if
+    absent, falls back to the env-configured default credential (the typical
+    stdio case under Claude Code, where ``HYDROLIX_TOKEN`` is set at server
+    launch and there is no per-request auth context).
     """
 
     async def on_request(self, context: MiddlewareContext, call_next) -> Any:
         try:
-            token = get_access_token()
-            if isinstance(token, AccessToken):
-                credential = token.as_credential()
-                # ``as_credential()`` is typed to return the abstract
-                # ``HydrolixCredential``; only the SA subtype carries
-                # ``service_account_id``. Guard rather than rely on the broad
-                # except below, so a non-SA credential skips cleanly without
-                # the misleading "logging failed" debug line.
-                if isinstance(credential, ServiceAccountToken):
-                    fields: dict[str, Any] = {
-                        "service_account_id": credential.service_account_id,
-                    }
-                    if context.method == "tools/call":
-                        tool_name = getattr(context.message, "name", None)
-                        if tool_name is not None:
-                            fields["tool_name"] = tool_name
-                    logger.info("mcp_request", extra=fields)
+            request_token = get_access_token()
+            credential = None
+            if isinstance(request_token, AccessToken):
+                credential = request_token.as_credential()
+            else:
+                # No per-request auth context (stdio, or HTTP without a bearer).
+                # Fall back to the env-configured default credential.
+                try:
+                    credential = get_config().creds_with(None)
+                except ValueError:
+                    # No default credential configured either — nothing to log.
+                    pass
+
+            # ``credential`` may be ``HydrolixCredential`` (abstract); only the
+            # SA subtype carries ``service_account_id``. Guard rather than rely
+            # on the broad except below so a non-SA credential (e.g.
+            # UsernamePassword) skips cleanly without a misleading "logging
+            # failed" debug line.
+            if isinstance(credential, ServiceAccountToken):
+                fields: dict[str, Any] = {
+                    "service_account_id": credential.service_account_id,
+                }
+                if context.method == "tools/call":
+                    tool_name = getattr(context.message, "name", None)
+                    if tool_name is not None:
+                        fields["tool_name"] = tool_name
+                logger.info("mcp_request", extra=fields)
         except Exception:
             # Attribution is best-effort; never let a malformed token or other
             # logging-path failure turn into a request error.

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -336,3 +336,40 @@ class TestJsonFormatter:
 
         assert "exception" in parsed
         assert "ValueError: Test error" in parsed["exception"]
+
+    def test_surfaces_extra_fields_at_top_level(self, formatter, log_record):
+        """Attributes set via ``logger.info(msg, extra={...})`` should appear
+        as top-level keys in the JSON output so downstream log processors can
+        index on them (e.g., service_account_id for query attribution)."""
+        import json
+
+        log_record.service_account_id = "sa-uuid-123"
+        log_record.jti = "token-uuid-456"
+
+        parsed = json.loads(formatter.format(log_record))
+
+        assert parsed["service_account_id"] == "sa-uuid-123"
+        assert parsed["jti"] == "token-uuid-456"
+
+    def test_does_not_duplicate_standard_logrecord_attributes(self, formatter, log_record):
+        """Standard LogRecord internals (lineno, pathname, etc.) must not leak
+        into the JSON envelope — only fields explicitly passed via ``extra``."""
+        import json
+
+        parsed = json.loads(formatter.format(log_record))
+
+        for leaked in ("lineno", "pathname", "filename", "module", "funcName", "args"):
+            assert leaked not in parsed, f"{leaked!r} leaked into JSON output"
+
+    def test_extras_do_not_overwrite_envelope_fields(self, formatter, log_record):
+        """If a caller accidentally passes ``extra={'level': ...}`` we must not
+        let that overwrite the canonical envelope field."""
+        import json
+
+        log_record.level = "tampered"  # via extra={'level': 'tampered'}
+        log_record.timestamp = "tampered"  # via extra={'timestamp': 'tampered'}
+
+        parsed = json.loads(formatter.format(log_record))
+
+        assert parsed["level"] == "INFO"
+        assert parsed["timestamp"] != "tampered"

--- a/tests/test_sa_attribution.py
+++ b/tests/test_sa_attribution.py
@@ -1,0 +1,209 @@
+"""Tests for the per-request service-account attribution middleware.
+
+The middleware emits one structured log line per authenticated MCP request so
+log aggregators can attribute queries back to a specific service account.
+Creator-email attribution (per HDX-11151) is deferred until turbine grows a
+``created_by`` field; see the module docstring for context.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from types import SimpleNamespace
+
+import jwt
+
+from mcp_hydrolix.auth import (
+    AccessToken,
+    HydrolixCredential,
+    HydrolixCredentialChain,
+    UsernamePassword,
+)
+
+
+def _make_jwt(claims: dict) -> str:
+    return jwt.encode(claims, key="x" * 32, algorithm="HS256")
+
+
+def _base_claims(**overrides):
+    now = int(time.time())
+    claims = {
+        "iss": "https://test.invalid/config",
+        "aud": "config-api",
+        "sub": "sa-uuid-123",
+        "iat": now - 10,
+        "exp": now + 600,
+        "jti": "token-uuid-456",
+    }
+    claims.update(overrides)
+    return claims
+
+
+def _sa_access_token(claims: dict | None = None):
+    token = _make_jwt(claims or _base_claims())
+    return HydrolixCredentialChain.ServiceAccountAccess(
+        token=token,
+        client_id=HydrolixCredentialChain.ServiceAccountAccess.FAKE_CLIENT_ID,
+        scopes=[HydrolixCredentialChain.ServiceAccountAccess.FAKE_SCOPE],
+        expires_at=None,
+        resource=None,
+        claims={},
+        expected_issuer="https://test.invalid/config",
+    )
+
+
+def _ctx(method: str, tool_name: str | None = None):
+    """Build a minimal stand-in for ``fastmcp.server.middleware.MiddlewareContext``.
+
+    The middleware only reads ``.method`` and (for tools/call) ``.message.name``,
+    so a SimpleNamespace duck-types it without pulling in the FastMCP wiring."""
+    message = SimpleNamespace(name=tool_name) if tool_name else SimpleNamespace()
+    return SimpleNamespace(method=method, message=message)
+
+
+async def _ok(_ctx) -> str:
+    return "downstream-result"
+
+
+class TestSAAttributionMiddleware:
+    """Per-request attribution logging."""
+
+    def test_logs_service_account_id_for_authenticated_request(self, monkeypatch, caplog):
+        from mcp_hydrolix import sa_attribution
+
+        monkeypatch.setattr(sa_attribution, "get_access_token", lambda: _sa_access_token())
+
+        mw = sa_attribution.SAAttributionMiddleware()
+        with caplog.at_level(logging.INFO, logger="mcp_hydrolix.sa_attribution"):
+            result = asyncio.run(mw.on_request(_ctx("tools/list"), _ok))
+
+        assert result == "downstream-result"
+        records = [r for r in caplog.records if r.name == "mcp_hydrolix.sa_attribution"]
+        assert len(records) == 1
+        rec = records[0]
+        assert rec.service_account_id == "sa-uuid-123"
+
+    def test_includes_tool_name_for_tool_calls(self, monkeypatch, caplog):
+        from mcp_hydrolix import sa_attribution
+
+        monkeypatch.setattr(sa_attribution, "get_access_token", lambda: _sa_access_token())
+
+        mw = sa_attribution.SAAttributionMiddleware()
+        with caplog.at_level(logging.INFO, logger="mcp_hydrolix.sa_attribution"):
+            asyncio.run(mw.on_request(_ctx("tools/call", tool_name="run_select_query"), _ok))
+
+        rec = next(r for r in caplog.records if r.name == "mcp_hydrolix.sa_attribution")
+        assert rec.service_account_id == "sa-uuid-123"
+        assert rec.tool_name == "run_select_query"
+
+    def test_does_not_log_when_no_access_token(self, monkeypatch, caplog):
+        from mcp_hydrolix import sa_attribution
+
+        monkeypatch.setattr(sa_attribution, "get_access_token", lambda: None)
+
+        mw = sa_attribution.SAAttributionMiddleware()
+        with caplog.at_level(logging.INFO, logger="mcp_hydrolix.sa_attribution"):
+            result = asyncio.run(mw.on_request(_ctx("tools/list"), _ok))
+
+        assert result == "downstream-result"
+        assert not any(r.name == "mcp_hydrolix.sa_attribution" for r in caplog.records)
+
+    def test_skips_log_when_credential_is_not_a_service_account_token(self, monkeypatch, caplog):
+        """If a future ``AccessToken`` subclass yields a non-SA credential
+        (e.g. UsernamePassword), the middleware must skip rather than crash on
+        the missing ``service_account_id`` attribute. The broad except would
+        also catch this, but the explicit guard makes the intent clear."""
+        from mcp_hydrolix import sa_attribution
+
+        class _NonSAAccess(AccessToken):
+            def as_credential(self) -> HydrolixCredential:
+                return UsernamePassword(username="u", password="p")
+
+        non_sa_token = _NonSAAccess(
+            token="opaque",
+            client_id="fake-client",
+            scopes=["fake-scope"],
+            expires_at=None,
+            resource=None,
+            claims={},
+        )
+        monkeypatch.setattr(sa_attribution, "get_access_token", lambda: non_sa_token)
+
+        mw = sa_attribution.SAAttributionMiddleware()
+        with caplog.at_level(logging.DEBUG, logger="mcp_hydrolix.sa_attribution"):
+            result = asyncio.run(mw.on_request(_ctx("tools/list"), _ok))
+
+        assert result == "downstream-result"
+        # Skip cleanly: no INFO (no attribution) AND no DEBUG (no spurious
+        # "logging failed" — the credential simply wasn't an SA).
+        records = [r for r in caplog.records if r.name == "mcp_hydrolix.sa_attribution"]
+        assert records == []
+
+    def test_logging_failure_does_not_break_the_request(self, monkeypatch, caplog):
+        """A malformed JWT must not turn into a 500 — log path failures swallow,
+        the request continues. This is a stopgap log; correctness of the request
+        is more important than perfect attribution."""
+        from mcp_hydrolix import sa_attribution
+
+        # Build a "token" that will blow up at decode time inside as_credential().
+        bad = HydrolixCredentialChain.ServiceAccountAccess(
+            token="not-a-jwt",
+            client_id=HydrolixCredentialChain.ServiceAccountAccess.FAKE_CLIENT_ID,
+            scopes=[HydrolixCredentialChain.ServiceAccountAccess.FAKE_SCOPE],
+            expires_at=None,
+            resource=None,
+            claims={},
+            expected_issuer=None,
+        )
+        monkeypatch.setattr(sa_attribution, "get_access_token", lambda: bad)
+
+        mw = sa_attribution.SAAttributionMiddleware()
+        with caplog.at_level(logging.INFO, logger="mcp_hydrolix.sa_attribution"):
+            result = asyncio.run(mw.on_request(_ctx("tools/list"), _ok))
+
+        assert result == "downstream-result"
+        # The attribution line should be absent, but downstream still ran.
+        attribution_lines = [
+            r
+            for r in caplog.records
+            if r.name == "mcp_hydrolix.sa_attribution" and getattr(r, "service_account_id", None)
+        ]
+        assert attribution_lines == []
+
+
+class TestSAAttributionMiddlewareJsonOutput:
+    """End-to-end: extras should round-trip through JsonFormatter as top-level
+    JSON fields, matching the ticket's 'structured log output' requirement."""
+
+    def test_structured_fields_round_trip_through_json_formatter(self, monkeypatch):
+        import io
+
+        from mcp_hydrolix import sa_attribution
+        from mcp_hydrolix.log import JsonFormatter
+
+        monkeypatch.setattr(sa_attribution, "get_access_token", lambda: _sa_access_token())
+
+        stream = io.StringIO()
+        handler = logging.StreamHandler(stream)
+        handler.setFormatter(JsonFormatter())
+        logger = logging.getLogger("mcp_hydrolix.sa_attribution")
+        prev_level = logger.level
+        try:
+            logger.addHandler(handler)
+            logger.setLevel(logging.INFO)
+            mw = sa_attribution.SAAttributionMiddleware()
+            asyncio.run(mw.on_request(_ctx("tools/call", tool_name="list_databases"), _ok))
+        finally:
+            logger.removeHandler(handler)
+            logger.setLevel(prev_level)
+
+        lines = [ln for ln in stream.getvalue().splitlines() if ln.strip()]
+        assert len(lines) == 1
+        payload = json.loads(lines[0])
+        assert payload["service_account_id"] == "sa-uuid-123"
+        assert payload["tool_name"] == "list_databases"
+        assert "jti" not in payload
+        assert "mcp_method" not in payload

--- a/tests/test_sa_attribution.py
+++ b/tests/test_sa_attribution.py
@@ -149,6 +149,35 @@ class TestSAAttributionMiddleware:
         assert rec.service_account_id == "sa-uuid-123"
         assert rec.tool_name == "list_databases"
 
+    def test_skips_log_when_env_default_credential_is_username_password(self, monkeypatch, caplog):
+        """If the server is started with HYDROLIX_USER/HYDROLIX_PASSWORD (no
+        SA token), the env-default credential is a UsernamePassword. The
+        middleware must skip cleanly via the isinstance guard — no log line,
+        no DEBUG "logging failed" line, and call_next must still be invoked
+        so the tool handler proceeds normally."""
+        from mcp_hydrolix import sa_attribution
+
+        monkeypatch.setattr(sa_attribution, "get_access_token", lambda: None)
+
+        env_credential = UsernamePassword(username="bob", password="hunter2")
+
+        class _UserPassConfig:
+            def creds_with(self, request_credential):
+                return request_credential if request_credential is not None else env_credential
+
+        monkeypatch.setattr(sa_attribution, "get_config", lambda: _UserPassConfig())
+
+        mw = sa_attribution.SAAttributionMiddleware()
+        with caplog.at_level(logging.DEBUG, logger="mcp_hydrolix.sa_attribution"):
+            result = asyncio.run(mw.on_request(_ctx("tools/call", tool_name="list_databases"), _ok))
+
+        # call_next ran (request was not broken)
+        assert result == "downstream-result"
+        # Skip cleanly: no INFO (no SA to attribute) AND no DEBUG (no spurious
+        # "logging failed" — UsernamePassword is a supported credential type).
+        records = [r for r in caplog.records if r.name == "mcp_hydrolix.sa_attribution"]
+        assert records == []
+
     def test_skips_log_when_credential_is_not_a_service_account_token(self, monkeypatch, caplog):
         """If a future ``AccessToken`` subclass yields a non-SA credential
         (e.g. UsernamePassword), the middleware must skip rather than crash on

--- a/tests/test_sa_attribution.py
+++ b/tests/test_sa_attribution.py
@@ -99,10 +99,18 @@ class TestSAAttributionMiddleware:
         assert rec.service_account_id == "sa-uuid-123"
         assert rec.tool_name == "run_select_query"
 
-    def test_does_not_log_when_no_access_token(self, monkeypatch, caplog):
+    def test_does_not_log_when_no_access_token_and_no_env_credential(self, monkeypatch, caplog):
+        """No per-request token AND no env-configured default credential
+        (raises ValueError from creds_with) — middleware skips silently."""
         from mcp_hydrolix import sa_attribution
 
         monkeypatch.setattr(sa_attribution, "get_access_token", lambda: None)
+
+        class _NoCredsConfig:
+            def creds_with(self, _request_credential):
+                raise ValueError("no credentials")
+
+        monkeypatch.setattr(sa_attribution, "get_config", lambda: _NoCredsConfig())
 
         mw = sa_attribution.SAAttributionMiddleware()
         with caplog.at_level(logging.INFO, logger="mcp_hydrolix.sa_attribution"):
@@ -110,6 +118,36 @@ class TestSAAttributionMiddleware:
 
         assert result == "downstream-result"
         assert not any(r.name == "mcp_hydrolix.sa_attribution" for r in caplog.records)
+
+    def test_falls_back_to_env_default_credential_for_stdio(self, monkeypatch, caplog):
+        """For stdio transport (Claude Code's default), HYDROLIX_TOKEN becomes
+        the env-configured default credential — it is NOT injected per-request
+        and ``get_access_token()`` returns None. The middleware must fall back
+        to the default credential via ``creds_with(None)`` so attribution still
+        fires for stdio. This is the most common Claude Code setup."""
+        from mcp_hydrolix import sa_attribution
+        from mcp_hydrolix.auth.credentials import ServiceAccountToken
+
+        monkeypatch.setattr(sa_attribution, "get_access_token", lambda: None)
+
+        env_credential = ServiceAccountToken(
+            _make_jwt(_base_claims()), expected_iss="https://test.invalid/config"
+        )
+
+        class _StdioConfig:
+            def creds_with(self, request_credential):
+                return request_credential if request_credential is not None else env_credential
+
+        monkeypatch.setattr(sa_attribution, "get_config", lambda: _StdioConfig())
+
+        mw = sa_attribution.SAAttributionMiddleware()
+        with caplog.at_level(logging.INFO, logger="mcp_hydrolix.sa_attribution"):
+            result = asyncio.run(mw.on_request(_ctx("tools/call", tool_name="list_databases"), _ok))
+
+        assert result == "downstream-result"
+        rec = next(r for r in caplog.records if r.name == "mcp_hydrolix.sa_attribution")
+        assert rec.service_account_id == "sa-uuid-123"
+        assert rec.tool_name == "list_databases"
 
     def test_skips_log_when_credential_is_not_a_service_account_token(self, monkeypatch, caplog):
         """If a future ``AccessToken`` subclass yields a non-SA credential

--- a/tests/test_sa_attribution.py
+++ b/tests/test_sa_attribution.py
@@ -17,9 +17,7 @@ from types import SimpleNamespace
 import jwt
 
 from mcp_hydrolix.auth import (
-    AccessToken,
-    HydrolixCredential,
-    HydrolixCredentialChain,
+    ServiceAccountToken,
     UsernamePassword,
 )
 
@@ -42,17 +40,29 @@ def _base_claims(**overrides):
     return claims
 
 
-def _sa_access_token(claims: dict | None = None):
-    token = _make_jwt(claims or _base_claims())
-    return HydrolixCredentialChain.ServiceAccountAccess(
-        token=token,
-        client_id=HydrolixCredentialChain.ServiceAccountAccess.FAKE_CLIENT_ID,
-        scopes=[HydrolixCredentialChain.ServiceAccountAccess.FAKE_SCOPE],
-        expires_at=None,
-        resource=None,
-        claims={},
-        expected_issuer="https://test.invalid/config",
+def _sa_credential(claims: dict | None = None) -> ServiceAccountToken:
+    """Build a real ServiceAccountToken for tests. The JWT decoder skips
+    signature verification, so the key/algo used by ``_make_jwt`` is fine."""
+    return ServiceAccountToken(
+        _make_jwt(claims or _base_claims()),
+        expected_iss="https://test.invalid/config",
     )
+
+
+class _PassthroughConfig:
+    """Stand-in for HydrolixConfig.creds_with: returns the per-request
+    credential when present, else the env-supplied default (if any), else
+    raises ValueError (matching the real ``creds_with`` contract)."""
+
+    def __init__(self, env_default=None):
+        self._env_default = env_default
+
+    def creds_with(self, request_credential):
+        if request_credential is not None:
+            return request_credential
+        if self._env_default is not None:
+            return self._env_default
+        raise ValueError("no credentials")
 
 
 def _ctx(method: str, tool_name: str | None = None):
@@ -68,15 +78,16 @@ async def _ok(_ctx) -> str:
     return "downstream-result"
 
 
-class TestSAAttributionMiddleware:
+class TestServiceAccountAttributionMiddleware:
     """Per-request attribution logging."""
 
     def test_logs_service_account_id_for_authenticated_request(self, monkeypatch, caplog):
         from mcp_hydrolix import sa_attribution
 
-        monkeypatch.setattr(sa_attribution, "get_access_token", lambda: _sa_access_token())
+        monkeypatch.setattr(sa_attribution, "get_request_credential", _sa_credential)
+        monkeypatch.setattr(sa_attribution, "get_config", _PassthroughConfig)
 
-        mw = sa_attribution.SAAttributionMiddleware()
+        mw = sa_attribution.ServiceAccountAttributionMiddleware()
         with caplog.at_level(logging.INFO, logger="mcp_hydrolix.sa_attribution"):
             result = asyncio.run(mw.on_request(_ctx("tools/list"), _ok))
 
@@ -89,9 +100,10 @@ class TestSAAttributionMiddleware:
     def test_includes_tool_name_for_tool_calls(self, monkeypatch, caplog):
         from mcp_hydrolix import sa_attribution
 
-        monkeypatch.setattr(sa_attribution, "get_access_token", lambda: _sa_access_token())
+        monkeypatch.setattr(sa_attribution, "get_request_credential", _sa_credential)
+        monkeypatch.setattr(sa_attribution, "get_config", _PassthroughConfig)
 
-        mw = sa_attribution.SAAttributionMiddleware()
+        mw = sa_attribution.ServiceAccountAttributionMiddleware()
         with caplog.at_level(logging.INFO, logger="mcp_hydrolix.sa_attribution"):
             asyncio.run(mw.on_request(_ctx("tools/call", tool_name="run_select_query"), _ok))
 
@@ -99,20 +111,17 @@ class TestSAAttributionMiddleware:
         assert rec.service_account_id == "sa-uuid-123"
         assert rec.tool_name == "run_select_query"
 
-    def test_does_not_log_when_no_access_token_and_no_env_credential(self, monkeypatch, caplog):
-        """No per-request token AND no env-configured default credential
-        (raises ValueError from creds_with) — middleware skips silently."""
+    def test_does_not_log_when_no_request_credential_and_no_env_credential(
+        self, monkeypatch, caplog
+    ):
+        """No per-request credential AND no env-configured default credential
+        (``creds_with(None)`` raises ValueError) — middleware skips silently."""
         from mcp_hydrolix import sa_attribution
 
-        monkeypatch.setattr(sa_attribution, "get_access_token", lambda: None)
+        monkeypatch.setattr(sa_attribution, "get_request_credential", lambda: None)
+        monkeypatch.setattr(sa_attribution, "get_config", lambda: _PassthroughConfig())
 
-        class _NoCredsConfig:
-            def creds_with(self, _request_credential):
-                raise ValueError("no credentials")
-
-        monkeypatch.setattr(sa_attribution, "get_config", lambda: _NoCredsConfig())
-
-        mw = sa_attribution.SAAttributionMiddleware()
+        mw = sa_attribution.ServiceAccountAttributionMiddleware()
         with caplog.at_level(logging.INFO, logger="mcp_hydrolix.sa_attribution"):
             result = asyncio.run(mw.on_request(_ctx("tools/list"), _ok))
 
@@ -121,26 +130,19 @@ class TestSAAttributionMiddleware:
 
     def test_falls_back_to_env_default_credential_for_stdio(self, monkeypatch, caplog):
         """For stdio transport (Claude Code's default), HYDROLIX_TOKEN becomes
-        the env-configured default credential — it is NOT injected per-request
-        and ``get_access_token()`` returns None. The middleware must fall back
-        to the default credential via ``creds_with(None)`` so attribution still
-        fires for stdio. This is the most common Claude Code setup."""
+        the env-configured default credential — there is NO per-request auth
+        context, so ``get_request_credential()`` returns None. The middleware
+        must fall back to the default credential via ``creds_with(None)`` so
+        attribution still fires for stdio. This is the most common Claude
+        Code setup."""
         from mcp_hydrolix import sa_attribution
-        from mcp_hydrolix.auth.credentials import ServiceAccountToken
 
-        monkeypatch.setattr(sa_attribution, "get_access_token", lambda: None)
-
-        env_credential = ServiceAccountToken(
-            _make_jwt(_base_claims()), expected_iss="https://test.invalid/config"
+        monkeypatch.setattr(sa_attribution, "get_request_credential", lambda: None)
+        monkeypatch.setattr(
+            sa_attribution, "get_config", lambda: _PassthroughConfig(env_default=_sa_credential())
         )
 
-        class _StdioConfig:
-            def creds_with(self, request_credential):
-                return request_credential if request_credential is not None else env_credential
-
-        monkeypatch.setattr(sa_attribution, "get_config", lambda: _StdioConfig())
-
-        mw = sa_attribution.SAAttributionMiddleware()
+        mw = sa_attribution.ServiceAccountAttributionMiddleware()
         with caplog.at_level(logging.INFO, logger="mcp_hydrolix.sa_attribution"):
             result = asyncio.run(mw.on_request(_ctx("tools/call", tool_name="list_databases"), _ok))
 
@@ -157,17 +159,13 @@ class TestSAAttributionMiddleware:
         so the tool handler proceeds normally."""
         from mcp_hydrolix import sa_attribution
 
-        monkeypatch.setattr(sa_attribution, "get_access_token", lambda: None)
-
         env_credential = UsernamePassword(username="bob", password="hunter2")
+        monkeypatch.setattr(sa_attribution, "get_request_credential", lambda: None)
+        monkeypatch.setattr(
+            sa_attribution, "get_config", lambda: _PassthroughConfig(env_default=env_credential)
+        )
 
-        class _UserPassConfig:
-            def creds_with(self, request_credential):
-                return request_credential if request_credential is not None else env_credential
-
-        monkeypatch.setattr(sa_attribution, "get_config", lambda: _UserPassConfig())
-
-        mw = sa_attribution.SAAttributionMiddleware()
+        mw = sa_attribution.ServiceAccountAttributionMiddleware()
         with caplog.at_level(logging.DEBUG, logger="mcp_hydrolix.sa_attribution"):
             result = asyncio.run(mw.on_request(_ctx("tools/call", tool_name="list_databases"), _ok))
 
@@ -178,28 +176,20 @@ class TestSAAttributionMiddleware:
         records = [r for r in caplog.records if r.name == "mcp_hydrolix.sa_attribution"]
         assert records == []
 
-    def test_skips_log_when_credential_is_not_a_service_account_token(self, monkeypatch, caplog):
-        """If a future ``AccessToken`` subclass yields a non-SA credential
-        (e.g. UsernamePassword), the middleware must skip rather than crash on
-        the missing ``service_account_id`` attribute. The broad except would
-        also catch this, but the explicit guard makes the intent clear."""
+    def test_skips_log_when_request_credential_is_not_a_service_account_token(
+        self, monkeypatch, caplog
+    ):
+        """If a non-SA credential is somehow on the request (e.g. a future
+        AccessToken subtype yielding UsernamePassword), the middleware must
+        skip cleanly via the isinstance guard — no crash on the missing
+        ``service_account_id`` attribute."""
         from mcp_hydrolix import sa_attribution
 
-        class _NonSAAccess(AccessToken):
-            def as_credential(self) -> HydrolixCredential:
-                return UsernamePassword(username="u", password="p")
+        non_sa_credential = UsernamePassword(username="u", password="p")
+        monkeypatch.setattr(sa_attribution, "get_request_credential", lambda: non_sa_credential)
+        monkeypatch.setattr(sa_attribution, "get_config", _PassthroughConfig)
 
-        non_sa_token = _NonSAAccess(
-            token="opaque",
-            client_id="fake-client",
-            scopes=["fake-scope"],
-            expires_at=None,
-            resource=None,
-            claims={},
-        )
-        monkeypatch.setattr(sa_attribution, "get_access_token", lambda: non_sa_token)
-
-        mw = sa_attribution.SAAttributionMiddleware()
+        mw = sa_attribution.ServiceAccountAttributionMiddleware()
         with caplog.at_level(logging.DEBUG, logger="mcp_hydrolix.sa_attribution"):
             result = asyncio.run(mw.on_request(_ctx("tools/list"), _ok))
 
@@ -209,30 +199,25 @@ class TestSAAttributionMiddleware:
         records = [r for r in caplog.records if r.name == "mcp_hydrolix.sa_attribution"]
         assert records == []
 
-    def test_logging_failure_does_not_break_the_request(self, monkeypatch, caplog):
-        """A malformed JWT must not turn into a 500 — log path failures swallow,
-        the request continues. This is a stopgap log; correctness of the request
-        is more important than perfect attribution."""
+    def test_invalid_request_token_does_not_break_the_request(self, monkeypatch, caplog):
+        """If ``get_request_credential`` raises ValueError (e.g. malformed
+        per-request JWT), middleware must skip the log line cleanly and still
+        call call_next so the request proceeds. ``creds_with`` is the layer
+        that raises in the merged code path, but the same outcome must hold
+        when get_request_credential itself raises."""
         from mcp_hydrolix import sa_attribution
 
-        # Build a "token" that will blow up at decode time inside as_credential().
-        bad = HydrolixCredentialChain.ServiceAccountAccess(
-            token="not-a-jwt",
-            client_id=HydrolixCredentialChain.ServiceAccountAccess.FAKE_CLIENT_ID,
-            scopes=[HydrolixCredentialChain.ServiceAccountAccess.FAKE_SCOPE],
-            expires_at=None,
-            resource=None,
-            claims={},
-            expected_issuer=None,
-        )
-        monkeypatch.setattr(sa_attribution, "get_access_token", lambda: bad)
+        def _raises():
+            raise ValueError("The provided access token is invalid.")
 
-        mw = sa_attribution.SAAttributionMiddleware()
+        monkeypatch.setattr(sa_attribution, "get_request_credential", _raises)
+        monkeypatch.setattr(sa_attribution, "get_config", _PassthroughConfig)
+
+        mw = sa_attribution.ServiceAccountAttributionMiddleware()
         with caplog.at_level(logging.INFO, logger="mcp_hydrolix.sa_attribution"):
             result = asyncio.run(mw.on_request(_ctx("tools/list"), _ok))
 
         assert result == "downstream-result"
-        # The attribution line should be absent, but downstream still ran.
         attribution_lines = [
             r
             for r in caplog.records
@@ -241,7 +226,7 @@ class TestSAAttributionMiddleware:
         assert attribution_lines == []
 
 
-class TestSAAttributionMiddlewareJsonOutput:
+class TestServiceAccountAttributionMiddlewareJsonOutput:
     """End-to-end: extras should round-trip through JsonFormatter as top-level
     JSON fields, matching the ticket's 'structured log output' requirement."""
 
@@ -251,7 +236,8 @@ class TestSAAttributionMiddlewareJsonOutput:
         from mcp_hydrolix import sa_attribution
         from mcp_hydrolix.log import JsonFormatter
 
-        monkeypatch.setattr(sa_attribution, "get_access_token", lambda: _sa_access_token())
+        monkeypatch.setattr(sa_attribution, "get_request_credential", _sa_credential)
+        monkeypatch.setattr(sa_attribution, "get_config", _PassthroughConfig)
 
         stream = io.StringIO()
         handler = logging.StreamHandler(stream)
@@ -261,7 +247,7 @@ class TestSAAttributionMiddlewareJsonOutput:
         try:
             logger.addHandler(handler)
             logger.setLevel(logging.INFO)
-            mw = sa_attribution.SAAttributionMiddleware()
+            mw = sa_attribution.ServiceAccountAttributionMiddleware()
             asyncio.run(mw.on_request(_ctx("tools/call", tool_name="list_databases"), _ok))
         finally:
             logger.removeHandler(handler)


### PR DESCRIPTION
What does this PR do?
-----------------------

Adds per-request service-account attribution logging (HDX-11151) as a stopgap until query-head grows native SA query logging.

A new `SAAttributionMiddleware` emits one structured INFO log line per authenticated MCP request with `service_account_id` and (for `tools/call`) `tool_name` as top-level JSON fields, so log aggregators can attribute queries back to a specific service account and the tool it invoked.

**Two transports / two credential resolution paths**

The middleware resolves the effective credential the same way `create_hydrolix_client` already does:

1. **Per-request bearer token (HTTP / SSE).** The MCP client sends `Authorization: Bearer <sa-jwt>` (or `?token=<sa-jwt>`); `HydrolixCredentialChain` populates the auth context; `get_access_token()` returns it; middleware reads `as_credential()`.
2. **Env-configured default credential (stdio, or HTTP without per-request auth).** Server starts with `HYDROLIX_TOKEN` set; the token becomes `HydrolixConfig._default_credential`. `get_access_token()` returns `None`; middleware falls back to `get_config().creds_with(None)` to log the env-default SA.

A missing credential entirely (no `HYDROLIX_TOKEN` and no `HYDROLIX_USER`/`HYDROLIX_PASSWORD`) raises `ValueError` from `creds_with`, which the middleware catches; nothing is logged.

**Design**

1. `mcp_hydrolix/log/log.py` — `JsonFormatter` learned to surface caller-supplied `extra={...}` fields as top-level JSON keys, with envelope fields (`level`, `timestamp`, ...) protected from accidental clobbering via `setdefault`. The standard-LogRecord-attribute list is auto-detected at import time so it can't drift from stdlib.
2. `mcp_hydrolix/sa_attribution.py` (new) — defines `SAAttributionMiddleware`. Hooks `on_request`, resolves the effective credential (per-request token → env default fallback), guards on `isinstance(credential, ServiceAccountToken)`, and emits a structured `mcp_request` log. Failures are swallowed (logged at DEBUG) so a malformed token can't 500 the request — attribution is best-effort.
3. `mcp_hydrolix/mcp_server.py` — wires the middleware in alongside the existing `MetricsMiddleware`, unconditionally (no metrics flag gate).

**Scope kept tight** — only fields strictly useful for query attribution are logged:
- `service_account_id` — the explicit ticket requirement.
- `tool_name` (for `tools/call` only) — the "what" half of "who did what".

Other JWT claims (`jti`, `iss`, `mcp_method`, etc.) are intentionally not logged: forensics-only nice-to-haves outside the ticket's scope.

**What's NOT in this PR — to fully satisfy HDX-11151**

The ticket also asks for the SA *creator's email* on each request. The MCP server can't satisfy that today:
- The JWT carries only `iss`, `aud`, `sub`, `iat`, `exp`, `jti` (turbine `service_accounts/models.py:113-128`). No email.
- The `ServiceAccount` model itself has no `created_by` field. Creator is captured only in turbine's audit log at SA-creation time, not on the SA record.

To fully satisfy the ticket, a turbine-side change is required:

- Add `created_by` FK (or email field) to `ServiceAccount` and populate it at SA creation.
- Bake `created_by_email` into the JWT claim set in `ServiceAccountToken.claims_set`.
- Once that lands, this middleware picks up the new claim and adds it to the log line — small follow-up PR here.

**Unrelated pre-existing bug noticed but NOT fixed here**

While reading `mcp_hydrolix/auth/credentials.py` I spotted that `ServiceAccountToken.__init__` does `self.issued_at = claims["iss"]` on line 43. That's the wrong claim — `iss` is the issuer URL (a string), not the issued-at timestamp; the correct claim is `iat`. The field is annotated `issued_at: int` but holds a string. The bug is dormant because nothing in the codebase actually reads `ServiceAccountToken.issued_at` today, so there's no current runtime impact, but it's a foot-gun for any future code that does. Introduced in `b0bdec2c` (PR #24, ~5 months ago). Out of scope for this PR — should be a separate one-line fix.

**Notes for reviewers**

- **OpenSpec.** OpenSpec landed in the repo (#102) after this middleware was implemented; the design here is captured in this PR description rather than as an OpenSpec proposal/spec. Future features should use the OpenSpec workflow.
- **Claude Code stdio stderr-capture quirk.** Claude Code does **not** persistently capture stderr from stdio MCP servers — only the initial connection burst lands in `~/Library/Caches/claude-cli-nodejs/<cwd>/mcp-logs-<server>/*.jsonl`. This is a [known Claude Code limitation](https://github.com/anthropics/claude-code/issues/29035) (closed without fix), not specific to our middleware. The MCP server *does* emit all log lines correctly — they just don't reach the `.jsonl` file after the initial burst. If you review this PR locally via Claude Code and don't see attribution log lines, that's the cause, not the code. Use either the standalone HTTP verification path (Section A below) or the tee-wrapped local config (Section B below).

Does this PR meet the acceptance criteria?
--------------------------------------------

* [x] Documentation created/updated — `sa_attribution.py` module docstring documents both transports, the stopgap framing, and the creator-email gap
* [x] Tests added for this feature/bug — 11 new unit tests across `tests/test_log.py` (3) and `tests/test_sa_attribution.py` (8), covering: happy path, tool-call branch, no-credential skip, non-SA credential skip (per-request *and* env-default UsernamePassword), decode-failure swallow, end-to-end JSON round-trip, and the stdio fallback path
* [x] Does this change request have any security impacts? — Logs only `service_account_id` (opaque UUID, identifier-not-credential) and `tool_name` (protocol-level method name). No tokens, no PII, no query bodies. Existing token-redacting filter unaffected.

Release Notes
---------------------------------------------------

* Major changes:
    *
* Minor changes:
    * Per-request structured logging of service-account ID for query attribution (covers both HTTP bearer-token and stdio env-token transports)
* Bugfixes:
    *
* Issues Closed:
    * HDX-11151 (partially — see PR description for creator-email follow-up)
* Security impacts identified:
    *

Testing
--------------------------------------------

**Test plan — manual verification steps**

Three setups exercised. (A) and (B) are local; (C) is the actual in-cluster deployment.

> The cluster name in the ✅ "verified against" markers below (`qe-innovations-3`) is whatever cluster I happened to use — reviewers can substitute any cluster they have an SA token for.

### A) Local standalone HTTP (same code path as cluster)

Setup: run mcp-hydrolix locally with HTTP transport + an SA token; stderr → file. Substitute `</path/to/mcp-hydrolix>` with the directory containing this checkout.

```bash
export HYDROLIX_HOST=<cluster-host>.hydrolix.dev
export HYDROLIX_TOKEN=<sa-jwt>
export HYDROLIX_MCP_SERVER_TRANSPORT=http
export HYDROLIX_MCP_BIND_HOST=127.0.0.1
export HYDROLIX_MCP_BIND_PORT=8088
uv run --directory </path/to/mcp-hydrolix> --python 3.13 mcp-hydrolix 2>/tmp/http_stderr.log &
```

**Step 1 — send `initialize` + `tools/call list_databases` via curl with Bearer:**

```bash
TOKEN=<sa-jwt>
curl -s -X POST http://127.0.0.1:8088/mcp \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -H "Accept: application/json, text/event-stream" \
  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"t","version":"1"}}}'

curl -s -X POST http://127.0.0.1:8088/mcp \
  -H "Authorization: Bearer $TOKEN" \
  -H "Content-Type: application/json" \
  -H "Accept: application/json, text/event-stream" \
  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"list_databases","arguments":{}}}'
```

**Step 2 — inspect `/tmp/http_stderr.log`. Expected:**

- An `mcp_request` line with `service_account_id` (no `tool_name`) for `initialize`
- An `mcp_request` line with `service_account_id` AND `tool_name: "list_databases"`
- Existing in-handler INFO lines: `"Listing all databases"`, `"Creating Hydrolix client connection... using service account <uuid>"`, `"Found N databases"`

✅ Verified end-to-end against `qe-innovations-3` — every log line above appeared with the correct SA UUID.

When done, stop the background server: `kill %1` (or `pkill -f mcp-hydrolix`).

### B) Local Claude Code stdio (with tee wrapper)

**Important:** Claude Code's default stdio-server stderr capture only writes the initial burst to `~/Library/Caches/claude-cli-nodejs/.../mcp-logs-*/*.jsonl`. To see subsequent server stderr (including attribution lines for tool calls), wrap the command with `tee` so stderr is also mirrored to a file:

```json
"my-hdx-server": {
  "command": "/bin/bash",
  "args": [
    "-c",
    "exec /path/to/uv run --directory /path/to/mcp-hydrolix --python 3.13 mcp-hydrolix 2> >(tee -a /tmp/hdx-mcp-stderr.log >&2)"
  ],
  "env": {
    "HYDROLIX_HOST": "<cluster-host>.hydrolix.dev",
    "HYDROLIX_TOKEN": "<sa-jwt>"
  }
}
```

Substitute the four placeholders: `/path/to/uv` (your absolute `uv` binary path, e.g. `~/.local/bin/uv`), `/path/to/mcp-hydrolix` (this checkout), `<cluster-host>.hydrolix.dev`, and `<sa-jwt>`. The `tee` keeps Claude Code's own stderr capture intact while mirroring everything to the file.

Steps:

1. Update the qe-3 (or equivalent) entry in `~/.claude.json` with the tee wrapper above.
2. Restart Claude Code so the MCP server is relaunched with the wrapper.
3. `tail -F /tmp/hdx-mcp-stderr.log` in a separate terminal.
4. In Claude, ask it to call a tool (e.g., `get_table_info`, `list_tables`).
5. Expected: each tool call appends an `mcp_request` line with `service_account_id` AND `tool_name`, plus the existing in-handler INFO lines (`"Listing tables in database 'X'"`, `"Query returned N rows"`, etc.).

✅ Verified end-to-end via Claude Code stdio against `qe-innovations-3` — `get_table_info` and `list_tables` calls both produced complete `mcp_request` lines with the right SA UUID and tool names.

### C) In-cluster deployment

The production target. Builds a container image from this branch and rolls it out to a test cluster.

Setup:
- **Build a feature-branch image** by manually triggering the `Publish feature branch to GAR` workflow (`.github/workflows/publish-feature.yml`, `workflow_dispatch`) against this PR's branch. It produces an image at:
  ```
  us-docker.pkg.dev/hdx-art/t/mcp-hydrolix:branch-il-hdx-11151-sa-id-logging-<short-sha>
  ```
  (the tag format is `branch-<sanitized-ref>-<short-sha>`).
- Deploy that image to a Hydrolix test cluster — replace / upgrade the `mcp-hydrolix` Deployment so the pod runs it.
- The pod runs with `HYDROLIX_MCP_SERVER_TRANSPORT=http` and uvicorn; stderr → container stdout → cluster log driver → log aggregator.

Steps:

1. **Identify the pod**:
   ```bash
   kubectl -n <namespace> get pods -l app=mcp-hydrolix
   ```
2. **Open a live log tail**:
   ```bash
   kubectl -n <namespace> logs -f <pod-name> | grep -E 'sa_attribution|mcp_request|service account'
   ```
   (Or query the cluster's log aggregator for `logger:"mcp_hydrolix.sa_attribution"` if you want indexed search.)
3. **Send an authenticated MCP request** to the deployed endpoint. The exact URL (e.g. via Ingress at `/mcp`, a cluster-internal Service URL, or a sub-path) depends on the mcp-hydrolix deployment manifest for the target cluster — consult the Service/Ingress definition. Send a JSON-RPC `initialize` followed by `tools/call list_databases` using the same curl payloads as Section A.

   **Note on auth at the cluster edge:** Hydrolix's ingress only accepts the `Authorization: Bearer <token>` form — the `?token=<token>` query-param form is rejected at the edge with a bare `401: Unauthorized` (returned by the Hydrolix proxy, before the request reaches the pod). Both forms work locally in Section A because there's no Hydrolix ingress in front of `127.0.0.1`. For in-cluster testing, **use the Bearer header**.
4. **Verify** in the live log tail / aggregator:
   - `mcp_request` line with `service_account_id` for `initialize`
   - `mcp_request` line with `service_account_id` AND `tool_name: "list_databases"` for the tool call
   - All existing in-handler INFO lines also visible
5. **Confirm aggregator filtering** — query the log aggregator with `service_account_id = "<uuid>"`; the matching requests should be returned. This is the actual production use case for HDX-11151.

✅ Verified end-to-end against `qe-innovations-3` — image `branch-il-hdx-11151-sa-id-logging-5ccd8e7` deployed to the cluster, Bearer-authenticated `initialize` + `tools/call list_databases` returned correct results, and pod logs show `mcp_request` lines with `service_account_id: "60a6a69e-..."` and `tool_name: "list_databases"`, plus all existing in-handler INFO lines (`"Listing all databases"`, `"Creating Hydrolix client connection to query-head:8088 using service account 60a6a69e-..."`, `"Found 19 databases"`).

### Cross-cutting

- **Health endpoints** (`/health`, `/healthz`) don't emit attribution logs — they're HTTP `custom_route` handlers, not MCP protocol requests, so middleware doesn't see them.
- **Malformed JWT** — middleware's broad `except` catches decode errors and swallows them at DEBUG; request still proceeds.
- **No credentials configured** — `HydrolixConfig.__init__` requires only `HYDROLIX_HOST`; credential env vars are checked lazily. If neither `HYDROLIX_TOKEN` nor `HYDROLIX_USER`+`PASSWORD` is set, the server *starts* fine, but on the first request `creds_with(None)` raises `ValueError`. The middleware catches it (no attribution line emitted); the tool handler then fails the same way and the tool call returns an error to the client.
- **`HYDROLIX_USER`+`HYDROLIX_PASSWORD` (no SA token) — no regression.** Verified end-to-end:
  - *HTTP transport:* `HydrolixCredentialChain` (the auth provider) requires a per-request Bearer for *inbound* auth — env user/pass is for the *outbound* ClickHouse connection only. Requests without a Bearer get `401 invalid_token` at the Starlette auth layer, *before* reaching our middleware. Pre-existing behavior, unchanged by this PR. Tested locally against `hdx-lab-innovations` with HTTP server + user/pass env vars + curl without Bearer → 401.
  - *Stdio transport:* no inbound auth layer; the env-supplied UsernamePassword is resolved via `creds_with(None)`. Our `isinstance(credential, ServiceAccountToken)` guard makes the middleware skip the log block silently; `call_next` runs and the tool handler authenticates outbound to ClickHouse with the env user/pass. No log line emitted (correct — no SA to attribute), no errors, no spurious DEBUG noise. Locked in by `test_skips_log_when_env_default_credential_is_username_password`.

**Automated tests**

* `uv run pytest tests/ --ignore=tests/e2e -m "not integration_clickhouse and not end_to_end"` → 222 passed, 33 deselected
* `uv run ruff check` and `uv run ruff format --check` → clean
* Integration tests (`integration_clickhouse`) and e2e tests not run — need live ClickHouse / k8s

🤖 Generated with [Claude Code](https://claude.com/claude-code)


