### PR TITLE
[IL][HDX-11481] include version and transport in hdx_query_admin_comment

### DIFF
--- a/mcp_hydrolix/mcp_server.py
+++ b/mcp_hydrolix/mcp_server.py
@@ -1,5 +1,6 @@
 import asyncio
 import base64
+import importlib.metadata
 import logging
 import time
 from pathlib import Path
@@ -57,6 +58,7 @@ from mcp_hydrolix.utils import coerce_rows, inject_limit
 
 
 MCP_SERVER_NAME = "mcp-hydrolix"
+_MCP_VERSION = importlib.metadata.version(MCP_SERVER_NAME)
 logger = logging.getLogger(MCP_SERVER_NAME)
 
 load_dotenv()
@@ -232,7 +234,10 @@ async def execute_query(
                 "hdx_query_max_attempts": 1,
                 "hdx_query_max_result_rows": 100_000,
                 "hdx_query_max_memory_usage": 2 * 1024 * 1024 * 1024,  # 2GiB
-                "hdx_query_admin_comment": f"User: {MCP_SERVER_NAME}",
+                "hdx_query_admin_comment": (
+                    f"User: {MCP_SERVER_NAME}, {_MCP_VERSION} "
+                    f"({HYDROLIX_CONFIG.mcp_server_transport})"
+                ),
             } | (extra_settings or {})
             res = await client.query(
                 query,

--- a/openspec/changes/enrich-admin-comment/proposal.md
+++ b/openspec/changes/enrich-admin-comment/proposal.md
@@ -1,0 +1,26 @@
+# Proposal: Include version and transport in `hdx_query_admin_comment`
+
+> Jira: [HDX-11481](https://hydrolix.atlassian.net/browse/HDX-11481)
+> Branch: `il/hdx-11481-admin-comment`
+
+## Intent
+
+`mcp_server.py:235` tags every query with the static string
+`"User: mcp-hydrolix"`. The data team needs to split MCP usage by
+deployment mode (local stdio vs. hosted http/sse) and by server version,
+and can't with a constant.
+
+## Scope
+
+Change the value of `hdx_query_admin_comment` from
+`"User: mcp-hydrolix"` to `"User: mcp-hydrolix, <version> (<transport>)"`,
+e.g. `"User: mcp-hydrolix, 0.3.2 (stdio)"`.
+
+## Approach
+
+- Read version once via `importlib.metadata.version("mcp-hydrolix")` at
+  module load.
+- Read transport per call via the existing
+  `HydrolixConfig.mcp_server_transport`.
+- Keep the existing `User: mcp-hydrolix` prefix so historical parsers /
+  greps continue to match; append the new fields after a comma.

--- a/openspec/changes/enrich-admin-comment/specs/query-execution/spec.md
+++ b/openspec/changes/enrich-admin-comment/specs/query-execution/spec.md
@@ -1,0 +1,21 @@
+# Delta for query-execution
+
+## MODIFIED Requirements
+
+### Requirement: `hdx_query_admin_comment` identifies version and transport
+Previously, `execute_query` set `hdx_query_admin_comment` to
+`"User: mcp-hydrolix"` for every query. The setting SHALL now be
+`"User: mcp-hydrolix, <version> (<transport>)"`, where `<version>` is the
+installed `mcp-hydrolix` package version and `<transport>` is one of
+`stdio`, `http`, `sse`.
+
+#### Scenario: Stdio deployment, version 0.3.2
+- GIVEN `HYDROLIX_MCP_SERVER_TRANSPORT=stdio`
+- AND the installed package version is `0.3.2`
+- WHEN `execute_query` builds its settings
+- THEN `hdx_query_admin_comment` SHALL equal `"User: mcp-hydrolix, 0.3.2 (stdio)"`
+
+#### Scenario: HTTP deployment
+- GIVEN `HYDROLIX_MCP_SERVER_TRANSPORT=http`
+- WHEN `execute_query` builds its settings
+- THEN `hdx_query_admin_comment` SHALL end with `" (http)"`

--- a/openspec/changes/enrich-admin-comment/tasks.md
+++ b/openspec/changes/enrich-admin-comment/tasks.md
@@ -1,0 +1,11 @@
+# Tasks
+
+## 1. Implement
+- [ ] 1.1 In `mcp_hydrolix/mcp_server.py`, resolve the package version at module scope via `importlib.metadata.version("mcp-hydrolix")`.
+- [ ] 1.2 Replace the literal at line 235 with `f"User: mcp-hydrolix, {_VERSION} ({HYDROLIX_CONFIG.mcp_server_transport})"`.
+
+## 2. Test
+- [ ] 2.1 Extend `tests/test_query_settings.py` to assert `hdx_query_admin_comment` matches the pattern `^User: mcp-hydrolix, [^ ]+ \((stdio|http|sse)\)$`, parameterised over transport via monkeypatched `HYDROLIX_MCP_SERVER_TRANSPORT`.
+
+## 3. Verify
+- [ ] 3.1 `uv run pytest` and `uv run ruff check` clean.

--- a/tests/test_query_settings.py
+++ b/tests/test_query_settings.py
@@ -8,6 +8,7 @@ Verifies that:
 """
 
 import inspect
+import re
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -163,3 +164,32 @@ class TestQuerySettings:
         settings = kwargs["settings"]
         assert "hdx_query_timerange_required" not in settings
         assert "hdx_query_max_timerange_sec" not in settings
+
+    @pytest.mark.parametrize("transport", ["stdio", "http", "sse"])
+    @patch("mcp_hydrolix.mcp_server.create_hydrolix_client")
+    async def test_admin_comment_includes_version_and_transport(
+        self, mock_create_client, monkeypatch, transport
+    ):
+        """hdx_query_admin_comment must identify the MCP server, its version,
+        and the active transport mode."""
+        from mcp_hydrolix.mcp_server import execute_query
+
+        monkeypatch.setenv("HYDROLIX_MCP_SERVER_TRANSPORT", transport)
+
+        mock_client = AsyncMock()
+        mock_query_result = AsyncMock()
+        mock_query_result.column_names = ["id"]
+        mock_query_result.result_rows = [[1]]
+        mock_client.query.return_value = mock_query_result
+
+        mock_ctx = AsyncMock()
+        mock_ctx.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_ctx.__aexit__ = AsyncMock(return_value=False)
+        mock_create_client.return_value = mock_ctx
+
+        await execute_query("SELECT 1")
+
+        _, kwargs = mock_client.query.call_args
+        comment = kwargs["settings"]["hdx_query_admin_comment"]
+        assert re.fullmatch(r"User: mcp-hydrolix, [^ ]+ \((stdio|http|sse)\)", comment), comment
+        assert comment.endswith(f"({transport})")


### PR DESCRIPTION
The static "User: mcp-hydrolix" admin comment doesn't allow visibility into MCP usage by deployment mode (local stdio vs hosted http/sse) or by server version. Proposed format: "User: mcp-hydrolix, <version> (<transport>)", e.g. "User: mcp-hydrolix, 0.3.2 (stdio)".

What does this PR do?
-----------------------
There are two changes in this PR: the first one is just a spec and the second one is an implementation of the spec.

Does this PR meet the acceptance criteria?
--------------------------------------------

* [ ] Documentation created/updated
* [x] Tests added for this feature/bug
* [ ] Does this change request have any security impacts?

Release Notes
---------------------------------------------------

* Major changes:
    *
* Minor changes:
    *
* Bugfixes:
    * HDX-11481
* Issues Closed:
    *
* Security impacts identified:
    *

Testing
--------------------------------------------
