### PR TITLE
[HDX-11441] Spec: HYDROLIX_URL config cleanup

### DIFF
--- a/openspec/changes/hydrolix-url-config-collapse/.openspec.yaml
+++ b/openspec/changes/hydrolix-url-config-collapse/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-08

--- a/openspec/changes/hydrolix-url-config-collapse/design.md
+++ b/openspec/changes/hydrolix-url-config-collapse/design.md
@@ -1,0 +1,127 @@
+## Context
+
+mcp-hydrolix connects to other Hydrolix cluster services via two HTTP endpoints: a ClickHouse-HTTP query-head and a REST `/version` probe from the version service. Today, six env vars configure these endpoints: `HYDROLIX_HOST`, `HYDROLIX_PORT`, `HYDROLIX_SECURE`, `HYDROLIX_API_HOST`, `HYDROLIX_API_PORT` (plus the implicit scheme derivation from `HYDROLIX_SECURE`). These names conflate cluster identity with endpoint routing, and "API" is ambiguous in a system with multiple APIs.
+
+Three deployment shapes exist:
+- **In-cluster Remote ("Internal")** (o6r-managed): env vars point at distinct internal k8s services (`turbine-query:8088` for queries, `version:23925` for the REST probe). `HYDROLIX_URL` is already present in pod environments via the "general" ConfigMap but is not currently consumed by `HydrolixConfig`.
+- **Out-of-cluster Remote ("External")** (testing, possible enterprise deployments): all vars typically converge on one canonical hostname (`*.trafficpeak.live` / `*.hydrolix.live`).
+- **Local** (stdio transport): all vars typically converge on one canonical hostname
+
+Upcoming OAuth work (HDX-11442) requires the cluster's canonical public URL at runtime, which is not derivable from an internal service hostname.
+
+**Stakeholders**: external mcp-hydrolix users, SRE operators, the OAuth feature stream.
+
+## Goals / Non-Goals
+
+**Goals:**
+- `HYDROLIX_URL` alone is a sufficient config for typical deployments (key design constraint).
+- Clear separation between cluster identity (`HYDROLIX_URL`) and endpoint overrides (`HTTP_QUERY_*`, `VERSION_API_*`).
+- All five legacy names remain honored with audience-appropriate deprecation messaging.
+- Zero functional drift for existing `HYDROLIX_HOST`-only configurations.
+- Zero functional drift for in-cluster deployments during the transition window (o6r still emitting old names).
+- Internal-facing deprecation notices stay in server logs only (never reach the LLM/end-user).
+- External-facing deprecation notices are visible once per session to the LLM/end-user.
+
+**Non-Goals:**
+- o6r migration (separate repo, separate PR, ships after this).
+- Removal of deprecated aliases (future release, separate ticket).
+- Changes to `HYDROLIX_VERIFY`, `HYDROLIX_TOKEN`, `HYDROLIX_USER`, `HYDROLIX_PASSWORD`, or any MCP bind/transport vars.
+- Changes to `HYDROLIX_PROXY_PATH` (planned for removal from codebase).
+- OAuth implementation itself.
+
+## Decisions
+
+### D1: Two-layer config model: Cluster identity
+
+The config model separates concerns into three layers:
+
+| Layer | Variables | Purpose |
+|---|---|---|
+| 1: Cluster identity | `HYDROLIX_URL` | Canonical public URL. Supplies defaults for all derived properties. |
+| 2: override (HTTP query) | `HYDROLIX_HTTP_QUERY_HOST/PORT/SECURE` | Override the ClickHouse HTTP query endpoint. Used for internal deployments. |
+| 3: override (Version-API) | `HYDROLIX_VERSION_API_HOST/PORT/SECURE` | Override the `/version` REST probe endpoint. Used for internal deployments. |
+
+**Rationale**: Separating identity from routing makes the external path simple (`HYDROLIX_URL` alone) while preserving the internal split-endpoint flexibility. The `HTTP_QUERY_` prefix disambiguates from native-protocol ports. The `VERSION_API_` prefix clarifies that "API" means the `/version` probe specifically.
+
+**Identity vs override**: Layer-1 (cluster identity) is the only layer that supplies a connection target. Layer-2 and Layer-3 are pure overrides and SHALL NEVER be sufficient on their own — setting `HYDROLIX_HTTP_QUERY_HOST` without a layer-1 value (URL, or the deprecated `HYDROLIX_HOST` for stdio) is a configuration error. The deprecated `HYDROLIX_HOST` alias is accepted as a layer-1 substitute only for stdio transport; http/sse transport requires `HYDROLIX_URL` specifically (OAuth metadata needs a canonical public URL).
+
+**Alternative rejected**: A single `HYDROLIX_QUERY_URL` + `HYDROLIX_VERSION_URL` (full URL overrides). This would require URL parsing in two more places and doesn't match the existing granular host/port/secure pattern that o6r already emits.
+
+### D2: Four-tier precedence chain
+
+For each derived property:
+```
+explicit new var > deprecated alias > HYDROLIX_URL-derived > hard-coded default
+```
+
+**Rationale**: New vars win over aliases (migration target takes precedence). Aliases win over URL-derived (a user who has explicitly set `HYDROLIX_HOST` intends that value even if `HYDROLIX_URL` is also present). URL-derived wins over hard defaults (the URL is the new canonical source).
+
+**Alternative rejected**: Making `HYDROLIX_URL` win over explicit aliases. This would not have sufficient expressivity for internal configurations, which rely on using different hostnames for the version and query services.
+
+### D3: URL port ignored -- scheme-default ports only
+
+`HYDROLIX_URL` with an explicit port (e.g. `https://cluster:9443`) ignores the port component and uses scheme-default (443/80). Clusters are always served on standard ports; non-standard ports are set via `HYDROLIX_HTTP_QUERY_PORT` or `HYDROLIX_VERSION_API_PORT`.
+
+**Rationale**: Prevents a likely misconfiguration where users copy a browser URL with a non-standard port and get unexpected query endpoint behavior. The URL is for identity, not routing.
+
+### D4: Audience detection via HYDROLIX_NAME
+
+`HYDROLIX_NAME` is an o6r-injected env var present in every pod via the "general" ConfigMap. Its presence is used as a proxy for "this is an o6r-managed deployment".
+
+**Rationale**: Simple, low false-positive risk (customers are extremely unlikely to set `HYDROLIX_NAME`), low false-negative risk (in-cluster pods always inherit the ConfigMap).
+
+**Alternative rejected**: Using `HYDROLIX_URL` presence as the signal. A partially-migrated external user who has set `HYDROLIX_URL` but still has `HYDROLIX_HOST` would be misclassified as internal and miss the LLM advisory.
+
+**Alternative rejected**: Dot-in-hostname heuristic (`turbine-query` has no dots, `mycluster.hydrolix.live` does). Brittle -- custom internal DNS names can have dots.
+
+### D5: Version gate for internal deprecation log
+
+The internal deprecation log only fires when the connected cluster reports version >= 6.1 (the first Hydrolix release whose bundled o6r emits the new names).
+
+**Rationale**: Operators on older clusters/o6r can't act on the notice -- logging it is noise. The gate ensures the log only appears where migration is actionable.
+
+**Implementation**: Piggybacks on the existing `_parse_hydrolix_version` -> `(major, minor)` tuple in the `/version` probe. The check is `parsed_version >= (6, 1)`.
+
+### D6: External deprecation via FastMCP instructions
+
+The external deprecation message is wired into `FastMCP(instructions=...)` at construction time.
+
+**Rationale**: The MCP protocol delivers `InitializeResult.instructions` once per client session. This is the correct channel for per-session operator advisories without adding custom middleware. When no deprecation is detected, `instructions` is `None` (matching current behavior). This prompts external MCP operators to update their configurations
+
+### D7: version_api_secure inherits from resolved secure
+
+`HYDROLIX_VERSION_API_SECURE` defaults to the resolved `secure` property (the HTTP query SECURE value after the full precedence chain). This means the common case (query and version-API use the same TLS setting) requires no explicit configuration, and o6r does not need to emit `HYDROLIX_VERSION_API_SECURE` at all.
+
+**Rationale**: In-cluster, `HYDROLIX_HTTP_QUERY_SECURE=false` (or its alias `HYDROLIX_SECURE=false`) implies the version probe is also plain HTTP. Explicit override is only needed for unusual setups where the two endpoints use different TLS modes.
+
+## Risks / Trade-offs
+
+- **BREAKING for external remote deployments (scoped break, explicit assumption)** -> Requiring `HYDROLIX_URL` when `HYDROLIX_MCP_SERVER_TRANSPORT` is `http` or `sse` is a hard breaking change for any deployment that today runs the http/sse transport without `HYDROLIX_URL` set. Scope analysis:
+  - **Internal remote (o6r-managed):** unaffected. o6r injects `HYDROLIX_URL` into every pod via the "general" ConfigMap; the variable is already present, just not consumed by `HydrolixConfig` today.
+  - **Stdio (local / IDE clients):** unaffected. The transport requirement only fires for `http`/`sse`.
+  - **External remote:** breaks for any operator running http/sse without `HYDROLIX_URL`. They hit a startup `ValueError` naming `HYDROLIX_URL` and `HYDROLIX_MCP_SERVER_TRANSPORT` and must set `HYDROLIX_URL` to recover.
+
+  **Explicit assumption (load-bearing):** we are not aware of any extant external remote deployments today. The break is acceptable on that basis. If this assumption is wrong, the cost to affected operators is one config edit (set `HYDROLIX_URL`), surfaced by a clear, actionable startup error — not a silent regression. We are NOT relying on a runtime warning or grace period to soften the break, because OAuth metadata generation cannot proceed without a canonical URL.
+
+- **Audience-detection heuristic is not 100% accurate** -> Misclassification is non-fatal in either direction. A misclassified-as-internal external user just sees the log without LLM nudging (can still find guidance in README). The single `_classify_deprecation()` helper is the touch-point to refine if reports accumulate.
+
+- **Internal deprecation log never fires if `/version` probe fails repeatedly** -> Acceptable degradation. The deprecation is informational, not critical. Probe failure produces its own pre-existing WARNING log. Operators can find guidance in README and release notes.
+
+- **Operator sets both old and new names during hand-migration** -> Precedence rule makes `HTTP_QUERY_*` win. Internal deprecation log fires for the old alias, which is the correct signal to finish removing it.
+
+- **URL with userinfo** (`https://user:pass@host`) -> `urlparse.hostname` strips userinfo. Documented as silently ignored. Credentials stay in their dedicated env vars. Again, URL is identity, not routing.
+
+- **Test env bleed from `.env` files** -> `autouse=True` fixture clears every `HYDROLIX_*` env var before each test in new test modules.
+
+## Migration Plan
+
+1. Ship mcp-hydrolix with this change (Phases 1-5 of the implementation plan).
+2. External users see the deprecation advisory and can migrate at their pace. Existing configs continue to work unchanged.
+3. After this release is deployed, switch o6r to emit the new names (Phase 6, separate repo/PR).
+4. After o6r migration and bake time, remove the five deprecated aliases in a future release (separate ticket).
+
+Rollback: Revert the mcp-hydrolix release. All old env var names continue to work because aliases are additive.
+
+## Open Questions
+
+(none -- resolved during planning)

--- a/openspec/changes/hydrolix-url-config-collapse/proposal.md
+++ b/openspec/changes/hydrolix-url-config-collapse/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+mcp-hydrolix needs its cluster's canonical public URL at runtime for upcoming OAuth features: token issuer validation (HDX-11167, HDX-11443) compares `iss` claims against the cluster identity, and OAuth resource-server metadata (`/.well-known/oauth-protected-resource`) advertises it. Today the only "host" configs can point at an internal k8s service name like `turbine-query`, which is insufficient for either feature. Before auth work can ship cleanly, the connection config needs a first-class "cluster public URL" input, and the surrounding naming ambiguities (`HYDROLIX_HOST` serving dual roles, `HYDROLIX_API_HOST` being misleadingly named) should be resolved while the touchpoints are open.
+
+## What Changes
+
+- Introduce `HYDROLIX_URL` as the primary cluster identity input (e.g. `https://mycluster.hydrolix.live`). For external deployments, this single variable is sufficient to derive all connection parameters.
+- Introduce `HYDROLIX_HTTP_QUERY_HOST`, `HYDROLIX_HTTP_QUERY_PORT`, `HYDROLIX_HTTP_QUERY_SECURE` as dedicated override channels for the ClickHouse HTTP query endpoint (splitting the dual role of the old `HYDROLIX_HOST/PORT/SECURE` trio).
+- Rename `HYDROLIX_API_HOST` / `HYDROLIX_API_PORT` to `HYDROLIX_VERSION_API_HOST` / `HYDROLIX_VERSION_API_PORT` to reflect their actual purpose (the `/version` REST probe, not a generic API).
+- Add `HYDROLIX_VERSION_API_SECURE` property (no prior equivalent existed) that inherits from the resolved HTTP query SECURE value by default.
+- Universally deprecate five legacy env vars: `HYDROLIX_HOST`, `HYDROLIX_PORT`, `HYDROLIX_SECURE`, `HYDROLIX_API_HOST`, `HYDROLIX_API_PORT`. They remain honored during a transition period.
+- Implement audience-aware deprecation messaging:
+  - **External** (no `HYDROLIX_NAME`): WARNING log at startup + LLM-visible advisory via FastMCP `instructions` pointing to `HYDROLIX_URL` as the sufficient replacement.
+  - **Internal** (`HYDROLIX_NAME` set): ERROR log from the `/version` probe, gated on cluster version >= 6.1 (the first release whose hkt emits the new names). Never reaches the LLM/end-user.
+- **BREAKING** (future): The five deprecated aliases will be removed in a future release after hkt migration and bake time.
+- **BREAKING (scoped):** Require `HYDROLIX_URL` specifically when `HYDROLIX_MCP_SERVER_TRANSPORT` is `http` or `sse` (OAuth metadata needs the canonical URL). The break only affects **external** remote deployments, since o6r-managed (internal) remote deployments already inject `HYDROLIX_URL` via the "general" ConfigMap. This is acceptable on the explicit assumption that **no extant external remote deployments exist today** — if any do, those operators will hit a startup `ValueError` naming `HYDROLIX_URL` and `HYDROLIX_MCP_SERVER_TRANSPORT` and must set `HYDROLIX_URL`. Stdio transport is unaffected.
+- Update `_check_parameterized_query_support` to use the renamed `version_api_host`, `version_api_port`, and new `version_api_secure` properties.
+
+## Capabilities
+
+### New Capabilities
+
+- `connection-config`: How the server resolves where and how to talk to the cluster. Covers `HYDROLIX_URL` parsing and validation, connection target validation, transport-specific URL requirements, the four-tier precedence chain (explicit new var > deprecated alias > URL-derived > hard default) for all six derived properties (host, port, secure, version_api_host, version_api_port, version_api_secure), version probe URL construction, and the transitional deprecated-alias detection / audience-aware messaging behavior. The transitional requirements (alias detection, audience classification, external startup advisory + LLM `instructions` wiring, version-gated internal log) will be REMOVED in a future change once the five deprecated aliases are dropped.
+
+### Modified Capabilities
+
+(none -- no existing specs to modify)
+
+## Impact
+
+- **mcp_hydrolix/mcp_env.py**: Major changes -- URL parsing, precedence chain for all properties, deprecation detection/classification helpers, new `deprecation_notice` and `deprecation_audience` properties, updated `_validate_required_vars`.
+- **mcp_hydrolix/mcp_server.py**: Wire `instructions=` on `FastMCP` constructor, add version-gated internal deprecation log helper in the `/version` probe path, rename `api_host`/`api_port` references to `version_api_host`/`version_api_port`, switch probe scheme source to `version_api_secure`.
+- **tests/test_parameterized_queries.py**: Update mock attribute names from `api_host`/`api_port`/`secure` to `version_api_host`/`version_api_port`/`version_api_secure` in the probe path tests.
+- **tests/**: Three new test modules for URL+precedence, deprecation classification+messaging, and version-gated internal logging.
+- **README.md**: Document new variables, deprecation, and audience-specific migration guidance.
+- **No new dependencies**: All additions use stdlib (`urllib.parse`, `logging`).
+- **Downstream**: hkt migration (separate repo, separate PR) will switch env var names after this ships. Not part of this change.

--- a/openspec/changes/hydrolix-url-config-collapse/specs/connection-config/spec.md
+++ b/openspec/changes/hydrolix-url-config-collapse/specs/connection-config/spec.md
@@ -1,0 +1,440 @@
+## ADDED Requirements
+
+### Requirement: HYDROLIX_URL parsing and validation
+
+`HydrolixConfig` SHALL parse the `HYDROLIX_URL` environment variable at construction time and store it as an internal `ParseResult`. If the value is unset or empty, the parsed result SHALL be `None`. If set, the scheme MUST be `http` or `https` and the hostname MUST be non-empty; otherwise `HydrolixConfig.__init__` SHALL raise `ValueError` with the offending value.
+
+#### Scenario: Valid HTTPS URL
+- **WHEN** `HYDROLIX_URL=https://mycluster.hydrolix.live`
+- **THEN** ✅ `HydrolixConfig` constructs successfully and the parsed URL hostname is `mycluster.hydrolix.live` with scheme `https`
+
+#### Scenario: Valid HTTP URL
+- **WHEN** `HYDROLIX_URL=http://dev-cluster.internal`
+- **THEN** ✅ `HydrolixConfig` constructs successfully with hostname `dev-cluster.internal` and scheme `http`
+
+#### Scenario: URL with trailing slash
+- **WHEN** `HYDROLIX_URL=https://mycluster.hydrolix.live/`
+- **THEN** ✅ construction succeeds (trailing path is ignored for derivation purposes)
+
+#### Scenario: URL with userinfo
+- **WHEN** `HYDROLIX_URL=https://user:pass@mycluster.hydrolix.live`
+- **THEN** ✅ construction succeeds; hostname resolves to `mycluster.hydrolix.live` (userinfo is silently ignored)
+
+#### Scenario: URL with explicit port
+- **WHEN** `HYDROLIX_URL=https://mycluster.hydrolix.live:9443`
+- **THEN** ✅ construction succeeds; the URL port component is ignored for derivation (scheme-default ports are used instead)
+
+#### Scenario: Malformed URL -- missing scheme
+- **WHEN** `HYDROLIX_URL=mycluster.hydrolix.live`
+- **THEN** ❌ `HydrolixConfig.__init__` raises `ValueError`
+
+#### Scenario: Malformed URL -- unsupported scheme
+- **WHEN** `HYDROLIX_URL=ftp://mycluster.hydrolix.live`
+- **THEN** ❌ `HydrolixConfig.__init__` raises `ValueError`
+
+#### Scenario: Malformed URL -- no hostname
+- **WHEN** `HYDROLIX_URL=https://`
+- **THEN** ❌ `HydrolixConfig.__init__` raises `ValueError`
+
+#### Scenario: Malformed URL -- empty after strip
+- **WHEN** `HYDROLIX_URL=   `
+- **THEN** ✅ treated as unset (`None`); no `ValueError` from URL parsing itself
+
+### Requirement: Connection target validation
+
+The connection target (cluster identity) MUST come from either `HYDROLIX_URL` or the deprecated `HYDROLIX_HOST` alias. `HYDROLIX_HTTP_QUERY_HOST` is an override on top of the connection target and SHALL NEVER be sufficient on its own — it provides no cluster identity, only an override for the ClickHouse HTTP query endpoint. If neither `HYDROLIX_URL` nor `HYDROLIX_HOST` is set, `HydrolixConfig.__init__` SHALL raise `ValueError` naming both options (and not `HYDROLIX_HTTP_QUERY_HOST`).
+
+This requirement is the baseline applicable to all transports. The "HYDROLIX_URL required for HTTP/SSE transport" requirement further restricts the http/sse case: there, `HYDROLIX_HOST` alone is also insufficient and `HYDROLIX_URL` specifically is required.
+
+#### Scenario: No connection target set
+- **WHEN** neither `HYDROLIX_URL` nor `HYDROLIX_HOST` is set
+- **THEN** ❌ `HydrolixConfig.__init__` raises `ValueError` listing both `HYDROLIX_URL` and `HYDROLIX_HOST` (and not `HYDROLIX_HTTP_QUERY_HOST`)
+
+#### Scenario: Only HYDROLIX_URL set
+- **WHEN** only `HYDROLIX_URL=https://cluster.example.com` is set (no `HYDROLIX_HOST`, no `HYDROLIX_HTTP_QUERY_HOST`)
+- **THEN** ✅ construction succeeds
+
+#### Scenario: Only HYDROLIX_HOST set (backwards compat, stdio only)
+- **WHEN** only `HYDROLIX_HOST=cluster.example.com` is set and `HYDROLIX_MCP_SERVER_TRANSPORT=stdio` (no `HYDROLIX_URL`, no `HYDROLIX_HTTP_QUERY_HOST`)
+- **THEN** ✅ construction succeeds (deprecated path; http/sse case is covered by the transport requirement)
+
+#### Scenario: Only HYDROLIX_HTTP_QUERY_HOST set
+- **WHEN** only `HYDROLIX_HTTP_QUERY_HOST=turbine-query` is set (no `HYDROLIX_URL`, no `HYDROLIX_HOST`)
+- **THEN** ❌ `HydrolixConfig.__init__` raises `ValueError` naming `HYDROLIX_URL` and `HYDROLIX_HOST` (HTTP_QUERY_HOST is an override, never a standalone connection target)
+
+#### Scenario: HYDROLIX_HTTP_QUERY_HOST as override on top of URL
+- **WHEN** `HYDROLIX_URL=https://cluster.example.com` and `HYDROLIX_HTTP_QUERY_HOST=turbine-query` are set
+- **THEN** ✅ construction succeeds (HTTP_QUERY_HOST is a valid override on top of a connection target)
+
+
+### Requirement: HYDROLIX_URL required for HTTP/SSE transport
+
+When `HYDROLIX_MCP_SERVER_TRANSPORT` is `http` or `sse`, `HYDROLIX_URL` specifically MUST be set. If missing, `HydrolixConfig.__init__` SHALL raise `ValueError` naming both `HYDROLIX_URL` and the transport setting, even if `HYDROLIX_HOST` or `HYDROLIX_HTTP_QUERY_HOST` is set.
+
+#### Scenario: HTTP transport without HYDROLIX_URL
+- **WHEN** `HYDROLIX_MCP_SERVER_TRANSPORT=http` and `HYDROLIX_HOST=myhost` but `HYDROLIX_URL` is unset
+- **THEN** ❌ `HydrolixConfig.__init__` raises `ValueError` mentioning both `HYDROLIX_URL` and `HYDROLIX_MCP_SERVER_TRANSPORT`
+
+#### Scenario: SSE transport without HYDROLIX_URL
+- **WHEN** `HYDROLIX_MCP_SERVER_TRANSPORT=sse` and `HYDROLIX_HTTP_QUERY_HOST=myhost` but `HYDROLIX_URL` is unset
+- **THEN** ❌ `HydrolixConfig.__init__` raises `ValueError`
+
+#### Scenario: Stdio transport without HYDROLIX_URL
+- **WHEN** `HYDROLIX_MCP_SERVER_TRANSPORT=stdio` and `HYDROLIX_HOST=myhost` but `HYDROLIX_URL` is unset
+- **THEN** ✅ construction succeeds (HYDROLIX_URL is not required for stdio)
+
+### Requirement: Host property precedence
+
+The `host` property SHALL follow the precedence chain: `HYDROLIX_HTTP_QUERY_HOST` > `HYDROLIX_HOST` (deprecated alias) > `HYDROLIX_URL` hostname. If none resolve, construction fails per the connection target validation requirement.
+
+#### Scenario: Only HYDROLIX_URL
+- **WHEN** `HYDROLIX_URL=https://cluster.example.com` (no host overrides)
+- **THEN** ✅ `host` returns `cluster.example.com`
+
+#### Scenario: HYDROLIX_HOST alias only
+- **WHEN** `HYDROLIX_HOST=myhost.example.com` (no URL, no HTTP_QUERY_HOST)
+- **THEN** ✅ `host` returns `myhost.example.com`
+
+#### Scenario: HYDROLIX_HTTP_QUERY_HOST wins over alias
+- **WHEN** `HYDROLIX_HTTP_QUERY_HOST=turbine-query` and `HYDROLIX_HOST=myhost.example.com`
+- **THEN** ✅ `host` returns `turbine-query`
+
+#### Scenario: HYDROLIX_HTTP_QUERY_HOST wins over URL
+- **WHEN** `HYDROLIX_URL=https://cluster.example.com` and `HYDROLIX_HTTP_QUERY_HOST=turbine-query`
+- **THEN** ✅ `host` returns `turbine-query`
+
+#### Scenario: Deprecated alias wins over URL-derived
+- **WHEN** `HYDROLIX_URL=https://cluster.example.com` and `HYDROLIX_HOST=override.example.com`
+- **THEN** ✅ `host` returns `override.example.com`
+
+### Requirement: Port property precedence
+
+The `port` property SHALL follow the precedence chain: `HYDROLIX_HTTP_QUERY_PORT` > `HYDROLIX_PORT` (deprecated alias) > URL-derived (443 for https, 80 for http) > hard default `8088`.
+
+#### Scenario: URL-derived port (HTTPS)
+- **WHEN** `HYDROLIX_URL=https://cluster.example.com` (no port overrides)
+- **THEN** ✅ `port` returns `443`
+
+#### Scenario: URL-derived port (HTTP)
+- **WHEN** `HYDROLIX_URL=http://cluster.example.com` (no port overrides)
+- **THEN** ✅ `port` returns `80`
+
+#### Scenario: Hard default (no URL, no overrides)
+- **WHEN** `HYDROLIX_HOST=myhost` (no URL, no port vars)
+- **THEN** ✅ `port` returns `8088`
+
+#### Scenario: HYDROLIX_HTTP_QUERY_PORT wins
+- **WHEN** `HYDROLIX_URL=https://cluster.example.com` and `HYDROLIX_HTTP_QUERY_PORT=8088`
+- **THEN** ✅ `port` returns `8088`
+
+#### Scenario: Deprecated alias wins over URL-derived
+- **WHEN** `HYDROLIX_URL=https://cluster.example.com` and `HYDROLIX_PORT=9000`
+- **THEN** ✅ `port` returns `9000`
+
+#### Scenario: New var wins over deprecated alias
+- **WHEN** `HYDROLIX_HTTP_QUERY_PORT=8088` and `HYDROLIX_PORT=9000`
+- **THEN** ✅ `port` returns `8088`
+
+### Requirement: Secure property precedence
+
+The `secure` property SHALL follow the precedence chain: `HYDROLIX_HTTP_QUERY_SECURE` > `HYDROLIX_SECURE` (deprecated alias) > URL-derived (scheme == "https") > hard default `True`.
+
+#### Scenario: URL-derived secure (HTTPS)
+- **WHEN** `HYDROLIX_URL=https://cluster.example.com` (no secure overrides)
+- **THEN** ✅ `secure` returns `True`
+
+#### Scenario: URL-derived secure (HTTP)
+- **WHEN** `HYDROLIX_URL=http://cluster.example.com` (no secure overrides)
+- **THEN** ✅ `secure` returns `False`
+
+#### Scenario: Hard default (no URL, no overrides)
+- **WHEN** `HYDROLIX_HOST=myhost` (no URL, no secure vars)
+- **THEN** ✅ `secure` returns `True`
+
+#### Scenario: HYDROLIX_HTTP_QUERY_SECURE override
+- **WHEN** `HYDROLIX_URL=https://cluster.example.com` and `HYDROLIX_HTTP_QUERY_SECURE=false`
+- **THEN** ✅ `secure` returns `False`
+
+#### Scenario: Deprecated alias wins over URL-derived
+- **WHEN** `HYDROLIX_URL=https://cluster.example.com` and `HYDROLIX_SECURE=false`
+- **THEN** ✅ `secure` returns `False`
+
+### Requirement: Version API host precedence
+
+The `version_api_host` property SHALL follow the precedence chain: `HYDROLIX_VERSION_API_HOST` > `HYDROLIX_API_HOST` (deprecated alias) > URL hostname > fallback to resolved `host`.
+
+#### Scenario: Only HYDROLIX_URL
+- **WHEN** `HYDROLIX_URL=https://cluster.example.com` (no version-api overrides)
+- **THEN** ✅ `version_api_host` returns `cluster.example.com`
+
+#### Scenario: Fallback to resolved host
+- **WHEN** `HYDROLIX_HOST=myhost` (no URL, no version-api host vars)
+- **THEN** ✅ `version_api_host` returns `myhost`
+
+#### Scenario: HYDROLIX_VERSION_API_HOST wins
+- **WHEN** `HYDROLIX_URL=https://cluster.example.com` and `HYDROLIX_VERSION_API_HOST=version`
+- **THEN** ✅ `version_api_host` returns `version`
+
+#### Scenario: Deprecated alias wins over URL-derived
+- **WHEN** `HYDROLIX_URL=https://cluster.example.com` and `HYDROLIX_API_HOST=version`
+- **THEN** ✅ `version_api_host` returns `version`
+
+### Requirement: Version API port precedence
+
+The `version_api_port` property SHALL follow the precedence chain: `HYDROLIX_VERSION_API_PORT` > `HYDROLIX_API_PORT` (deprecated alias) > URL-derived (443/80 by scheme) > `443` if secure else `80`.
+
+#### Scenario: Default from secure=True
+- **WHEN** `HYDROLIX_HOST=myhost` (no URL, no version-api port vars, secure defaults to True)
+- **THEN** ✅ `version_api_port` returns `443`
+
+#### Scenario: URL-derived (HTTPS)
+- **WHEN** `HYDROLIX_URL=https://cluster.example.com` (no version-api overrides)
+- **THEN** ✅ `version_api_port` returns `443`
+
+#### Scenario: HYDROLIX_VERSION_API_PORT wins
+- **WHEN** `HYDROLIX_URL=https://cluster.example.com` and `HYDROLIX_VERSION_API_PORT=23925`
+- **THEN** ✅ `version_api_port` returns `23925`
+
+#### Scenario: Deprecated alias wins over URL-derived
+- **WHEN** `HYDROLIX_URL=https://cluster.example.com` and `HYDROLIX_API_PORT=23925`
+- **THEN** ✅ `version_api_port` returns `23925`
+
+### Requirement: Version API secure inherits from resolved secure
+
+The `version_api_secure` property SHALL follow the precedence: explicit `HYDROLIX_VERSION_API_SECURE` > resolved `secure` property. There is no deprecated alias for this property.
+
+#### Scenario: Inherits from URL-derived secure
+- **WHEN** `HYDROLIX_URL=https://cluster.example.com` (no explicit version_api_secure)
+- **THEN** ✅ `version_api_secure` returns `True` (inherits from `secure=True`)
+
+#### Scenario: Inherits from HTTP secure override
+- **WHEN** `HYDROLIX_URL=https://cluster.example.com` and `HYDROLIX_HTTP_QUERY_SECURE=false`
+- **THEN** ✅ `version_api_secure` returns `False` (inherits from resolved `secure=False`, not URL scheme)
+
+#### Scenario: Explicit override diverges from query secure
+- **WHEN** `HYDROLIX_URL=https://cluster.example.com` and `HYDROLIX_HTTP_QUERY_SECURE=false` and `HYDROLIX_VERSION_API_SECURE=true`
+- **THEN** ✅ `secure` returns `False` and `version_api_secure` returns `True`
+
+#### Scenario: Inherits through deprecated alias path
+- **WHEN** `HYDROLIX_HOST=host` and `HYDROLIX_SECURE=false` (no URL, no explicit version_api_secure)
+- **THEN** ✅ `version_api_secure` returns `False`
+
+### Requirement: External sufficiency
+
+With `HYDROLIX_URL=https://cluster.example.com` set alone (plus credentials), all six derived properties SHALL resolve correctly: `host=cluster.example.com`, `port=443`, `secure=True`, `version_api_host=cluster.example.com`, `version_api_port=443`, `version_api_secure=True`.
+
+#### Scenario: HYDROLIX_URL alone resolves all properties
+- **WHEN** `HYDROLIX_URL=https://cluster.example.com` and no other connection vars are set
+- **THEN** ✅ `host` is `cluster.example.com`, `port` is `443`, `secure` is `True`, `version_api_host` is `cluster.example.com`, `version_api_port` is `443`, `version_api_secure` is `True`
+
+#### Scenario: External sufficiency with split ports
+- **WHEN** `HYDROLIX_URL=https://cluster.example.com` and `HYDROLIX_HTTP_QUERY_PORT=8088` and `HYDROLIX_VERSION_API_PORT=9090`
+- **THEN** ✅ hostnames and secure still from URL; `port` is `8088`, `version_api_port` is `9090`, `version_api_secure` is `True`
+
+### Requirement: Backwards compatibility with HYDROLIX_HOST-only configs
+
+When only `HYDROLIX_HOST` is set (no URL, no new vars), the derived property values MUST match the pre-change behavior bit-for-bit: `port=8088`, `secure=True`, `version_api_host` falls back to `host`, `version_api_port=443`, `version_api_secure=True`.
+
+#### Scenario: Legacy HYDROLIX_HOST-only configuration
+- **WHEN** `HYDROLIX_HOST=myhost.example.com` and no other connection vars
+- **THEN** ✅ `host` is `myhost.example.com`, `port` is `8088`, `secure` is `True`, `version_api_host` is `myhost.example.com`, `version_api_port` is `443`, `version_api_secure` is `True`
+
+### Requirement: In-cluster post-migration shape
+
+With `HYDROLIX_URL` plus all new override vars (`HYDROLIX_HTTP_QUERY_HOST`, `HYDROLIX_HTTP_QUERY_PORT`, `HYDROLIX_HTTP_QUERY_SECURE`, `HYDROLIX_VERSION_API_HOST`, `HYDROLIX_VERSION_API_PORT`), every override SHALL win. `version_api_secure` SHALL be `False` via inheritance when `HYDROLIX_HTTP_QUERY_SECURE=false`.
+
+#### Scenario: Post-migration hkt env shape
+- **WHEN** `HYDROLIX_URL=https://cluster.example.com`, `HYDROLIX_HTTP_QUERY_HOST=turbine-query`, `HYDROLIX_HTTP_QUERY_PORT=8088`, `HYDROLIX_HTTP_QUERY_SECURE=false`, `HYDROLIX_VERSION_API_HOST=version`, `HYDROLIX_VERSION_API_PORT=23925`
+- **THEN** ✅ `host` is `turbine-query`, `port` is `8088`, `secure` is `False`, `version_api_host` is `version`, `version_api_port` is `23925`, `version_api_secure` is `False`
+
+### Requirement: In-cluster transition shape (deprecated aliases)
+
+With `HYDROLIX_URL` plus deprecated alias names (`HYDROLIX_HOST`, `HYDROLIX_PORT`, `HYDROLIX_SECURE`, `HYDROLIX_API_HOST`, `HYDROLIX_API_PORT`), aliases SHALL be honored and produce identical routing to the post-migration shape.
+
+#### Scenario: Transition-period hkt env shape
+- **WHEN** `HYDROLIX_URL=https://cluster.example.com`, `HYDROLIX_HOST=turbine-query`, `HYDROLIX_PORT=8088`, `HYDROLIX_SECURE=false`, `HYDROLIX_API_HOST=version`, `HYDROLIX_API_PORT=23925`
+- **THEN** ✅ `host` is `turbine-query`, `port` is `8088`, `secure` is `False`, `version_api_host` is `version`, `version_api_port` is `23925`, `version_api_secure` is `False`
+
+### Requirement: Version probe URL construction
+
+The `/version` probe URL in `_check_parameterized_query_support` SHALL use `version_api_host`, `version_api_port`, and `version_api_secure` (not `api_host`, `api_port`, and `secure`).
+
+#### Scenario: Out-of-cluster version URL
+- **WHEN** `HYDROLIX_URL=https://cluster.example.com` (no overrides)
+- **THEN** ✅ the `/version` probe URL is `https://cluster.example.com:443/version`
+
+#### Scenario: In-cluster version URL
+- **WHEN** `version_api_host=version`, `version_api_port=23925`, `version_api_secure=False`
+- **THEN** ✅ the `/version` probe URL is `http://version:23925/version`
+
+### Requirement: Deprecated alias detection
+
+**(Transitional — will be REMOVED when the five deprecated aliases are dropped in a future change.)** A `_detect_deprecated_aliases()` helper SHALL return the list of deprecated env var names that are currently set. The five deprecated aliases are: `HYDROLIX_HOST`, `HYDROLIX_PORT`, `HYDROLIX_SECURE`, `HYDROLIX_API_HOST`, `HYDROLIX_API_PORT`.
+
+#### Scenario: Single alias set
+- **WHEN** only `HYDROLIX_HOST` is set among the deprecated names
+- **THEN** ✅ `_detect_deprecated_aliases()` returns `["HYDROLIX_HOST"]`
+
+#### Scenario: Multiple aliases set
+- **WHEN** `HYDROLIX_HOST` and `HYDROLIX_API_PORT` are set
+- **THEN** ✅ `_detect_deprecated_aliases()` returns `["HYDROLIX_HOST", "HYDROLIX_API_PORT"]`
+
+#### Scenario: All five aliases set
+- **WHEN** all of `HYDROLIX_HOST`, `HYDROLIX_PORT`, `HYDROLIX_SECURE`, `HYDROLIX_API_HOST`, `HYDROLIX_API_PORT` are set
+- **THEN** ✅ `_detect_deprecated_aliases()` returns all five names
+
+#### Scenario: No aliases set
+- **WHEN** none of the five deprecated names are set
+- **THEN** ✅ `_detect_deprecated_aliases()` returns an empty list
+
+### Requirement: Deprecation audience classification
+
+**(Transitional — will be REMOVED when the five deprecated aliases are dropped in a future change.)** A `_classify_deprecation()` helper SHALL classify the deprecation audience based on `HYDROLIX_NAME`:
+- If no deprecated aliases are detected, return `None`.
+- If `HYDROLIX_NAME` is set, return `"internal"`.
+- If `HYDROLIX_NAME` is unset, return `"external"`.
+
+#### Scenario: No deprecated aliases
+- **WHEN** `_detect_deprecated_aliases()` returns `[]`
+- **THEN** ✅ `_classify_deprecation([])` returns `None`
+
+#### Scenario: External audience
+- **WHEN** `HYDROLIX_HOST` is set and `HYDROLIX_NAME` is unset
+- **THEN** ✅ `_classify_deprecation(["HYDROLIX_HOST"])` returns `"external"`
+
+#### Scenario: Internal audience
+- **WHEN** `HYDROLIX_HOST` is set and `HYDROLIX_NAME` is set
+- **THEN** ✅ `_classify_deprecation(["HYDROLIX_HOST"])` returns `"internal"`
+
+#### Scenario: Partial migration external user
+- **WHEN** `HYDROLIX_HOST` is set and `HYDROLIX_URL` is set but `HYDROLIX_NAME` is unset
+- **THEN** ✅ `_classify_deprecation(["HYDROLIX_HOST"])` returns `"external"` (partial-migration user still gets the LLM nudge)
+
+### Requirement: External deprecation log at startup
+
+**(Transitional — will be REMOVED when the five deprecated aliases are dropped in a future change.)** When the deprecation audience is `"external"`, `HydrolixConfig.__init__` SHALL emit a single WARNING-level log listing the offending deprecated alias(es) and advising the operator to set `HYDROLIX_URL`. The log SHALL fire at most once per process.
+
+#### Scenario: External WARNING log fires
+- **WHEN** `HYDROLIX_HOST` is set, `HYDROLIX_NAME` is unset, and `HydrolixConfig()` is constructed
+- **THEN** ✅ a WARNING log is emitted containing the deprecated alias name(s) and mentioning `HYDROLIX_URL` as the migration target
+
+#### Scenario: No duplicate logs
+- **WHEN** `HydrolixConfig()` is constructed a second time in the same process with the same deprecated aliases
+- **THEN** ✅ no additional WARNING log is emitted
+
+#### Scenario: Internal audience does not trigger startup log
+- **WHEN** `HYDROLIX_HOST` is set and `HYDROLIX_NAME` is set
+- **THEN** ✅ `HydrolixConfig.__init__` does NOT emit a WARNING log for deprecation
+
+### Requirement: deprecation_notice property for LLM delivery
+
+**(Transitional — will be REMOVED when the five deprecated aliases are dropped in a future change.)** `HydrolixConfig.deprecation_notice` SHALL return a non-empty string containing the external deprecation advisory when `deprecation_audience` is `"external"`. It SHALL return `None` when `deprecation_audience` is `"internal"` or `None`.
+
+#### Scenario: External deprecation notice
+- **WHEN** `deprecation_audience` is `"external"`
+- **THEN** ✅ `deprecation_notice` returns a string mentioning the deprecated alias(es) and `HYDROLIX_URL` as the sufficient migration target
+
+#### Scenario: Internal deprecation notice is None
+- **WHEN** `deprecation_audience` is `"internal"`
+- **THEN** ✅ `deprecation_notice` returns `None` (internal deprecation MUST NOT reach the LLM)
+
+#### Scenario: No deprecation
+- **WHEN** no deprecated aliases are set
+- **THEN** ✅ `deprecation_notice` returns `None`
+
+### Requirement: FastMCP instructions wiring
+
+**(Transitional — will be REMOVED when the five deprecated aliases are dropped in a future change.)** The `FastMCP` constructor SHALL receive `instructions=HYDROLIX_CONFIG.deprecation_notice`. When `deprecation_notice` is `None`, behavior matches the current codebase (no instructions). When non-`None`, every new MCP session's `InitializeResult.instructions` delivers the external advisory.
+
+#### Scenario: External deprecation delivered per session
+- **WHEN** external deprecated aliases are detected
+- **THEN** ✅ `FastMCP` is constructed with `instructions` set to the external deprecation message, and each client session receives this in `InitializeResult.instructions`
+
+#### Scenario: No deprecation -- no instructions
+- **WHEN** no deprecated aliases are detected
+- **THEN** ✅ `FastMCP` is constructed with `instructions=None`
+
+### Requirement: Version-gated internal deprecation log
+
+**(Transitional — will be REMOVED when the five deprecated aliases are dropped in a future change.)** When `deprecation_audience` is `"internal"` and the `/version` probe returns a parseable version >= 6.1, an ERROR-level log SHALL fire exactly once listing the deprecated aliases and their new replacements (`OLD -> NEW` pairs). The log SHALL NOT fire if:
+- The audience is not `"internal"`.
+- The parsed version is < 6.1.
+- The `/version` probe fails (HTTP error, non-200, unparseable body).
+
+#### Scenario: Internal log fires for version 6.1.0
+- **WHEN** `deprecation_audience` is `"internal"` and `/version` returns `"v6.1.0"`
+- **THEN** ✅ an ERROR log fires listing the deprecated aliases and their replacements
+
+#### Scenario: Internal log fires for version 7.0.0
+- **WHEN** `deprecation_audience` is `"internal"` and `/version` returns `"v7.0.0"`
+- **THEN** ✅ an ERROR log fires (>= 6.1 satisfied)
+
+#### Scenario: Internal log fires for dev version
+- **WHEN** `deprecation_audience` is `"internal"` and `/version` returns `"v6.1.0-5-gabcdef12"`
+- **THEN** ✅ an ERROR log fires (parsed as 6.1)
+
+#### Scenario: No log for version 6.0.9
+- **WHEN** `deprecation_audience` is `"internal"` and `/version` returns `"v6.0.9"`
+- **THEN** ✅ no deprecation log fires
+
+#### Scenario: No log for version 5.x
+- **WHEN** `deprecation_audience` is `"internal"` and `/version` returns `"v5.12.0"`
+- **THEN** ✅ no deprecation log fires
+
+#### Scenario: No log on probe failure
+- **WHEN** `deprecation_audience` is `"internal"` and `/version` HTTP request raises an exception
+- **THEN** ✅ no deprecation log fires; subsequent successful probe with version >= 6.1 SHALL fire the log
+
+#### Scenario: No log on non-200 response
+- **WHEN** `deprecation_audience` is `"internal"` and `/version` returns HTTP 500
+- **THEN** ✅ no deprecation log fires
+
+#### Scenario: No log on unparseable version
+- **WHEN** `deprecation_audience` is `"internal"` and `/version` returns `"garbage"`
+- **THEN** ✅ no deprecation log fires
+
+#### Scenario: Log fires at most once
+- **WHEN** the internal deprecation log has already fired
+- **THEN** ✅ subsequent `/version` probes SHALL NOT emit a second log
+
+#### Scenario: External audience -- no log from probe
+- **WHEN** `deprecation_audience` is `"external"` and `/version` returns `"v6.1.0"`
+- **THEN** ✅ no deprecation log fires from the probe path (external log was emitted at init time)
+
+#### Scenario: No deprecation -- no log from probe
+- **WHEN** no deprecated aliases are set and `/version` returns `"v6.1.0"`
+- **THEN** ✅ no deprecation log fires from the probe path
+
+### Requirement: Alias rename mapping
+
+**(Transitional — will be REMOVED when the five deprecated aliases are dropped in a future change.)** The mapping of deprecated aliases to their replacements SHALL be:
+
+| Deprecated | Replacement |
+|---|---|
+| `HYDROLIX_HOST` | `HYDROLIX_HTTP_QUERY_HOST` |
+| `HYDROLIX_PORT` | `HYDROLIX_HTTP_QUERY_PORT` |
+| `HYDROLIX_SECURE` | `HYDROLIX_HTTP_QUERY_SECURE` |
+| `HYDROLIX_API_HOST` | `HYDROLIX_VERSION_API_HOST` |
+| `HYDROLIX_API_PORT` | `HYDROLIX_VERSION_API_PORT` |
+
+The internal deprecation message SHALL include `OLD -> NEW` pairs for each detected alias. The external deprecation message SHALL list the detected alias names and point to `HYDROLIX_URL` as the sufficient replacement.
+
+#### Scenario: Internal message format
+- **WHEN** `HYDROLIX_HOST` and `HYDROLIX_API_PORT` are the detected aliases and audience is internal
+- **THEN** ✅ the internal log message includes `HYDROLIX_HOST -> HYDROLIX_HTTP_QUERY_HOST` and `HYDROLIX_API_PORT -> HYDROLIX_VERSION_API_PORT`
+
+#### Scenario: External message format
+- **WHEN** `HYDROLIX_HOST` is the detected alias and audience is external
+- **THEN** ✅ the external message mentions `HYDROLIX_HOST` and advises setting `HYDROLIX_URL`
+
+### Requirement: HydrolixConfig exposes deprecation state
+
+**(Transitional — will be REMOVED when the five deprecated aliases are dropped in a future change.)** `HydrolixConfig` SHALL expose `deprecated_aliases` (list of detected deprecated var names) and `deprecation_audience` (`"external"`, `"internal"`, or `None`) as readable properties, so the version-gated probe hook can inspect them.
+
+#### Scenario: Properties available for probe hook
+- **WHEN** `HYDROLIX_HOST` is set and `HYDROLIX_NAME` is set
+- **THEN** ✅ `HYDROLIX_CONFIG.deprecated_aliases` contains `"HYDROLIX_HOST"` and `HYDROLIX_CONFIG.deprecation_audience` is `"internal"`
+
+#### Scenario: No deprecation state
+- **WHEN** no deprecated aliases are set
+- **THEN** ✅ `HYDROLIX_CONFIG.deprecated_aliases` is empty and `HYDROLIX_CONFIG.deprecation_audience` is `None`

--- a/openspec/changes/hydrolix-url-config-collapse/tasks.md
+++ b/openspec/changes/hydrolix-url-config-collapse/tasks.md
@@ -1,0 +1,81 @@
+## 1. Core Config -- URL Parsing and Precedence Chain (mcp_env.py)
+
+- [ ] 1.1 Add `logging` and `urllib.parse.urlparse` / `ParseResult` imports; add module-level `logger`
+- [ ] 1.2 Parse `HYDROLIX_URL` eagerly in `HydrolixConfig.__init__` and store as `self._parsed_url: Optional[ParseResult]`; validate scheme in {http, https} and non-empty hostname; raise `ValueError` on malformed URL
+- [ ] 1.3 Update `host` property to follow precedence: `HYDROLIX_HTTP_QUERY_HOST` > `HYDROLIX_HOST` > URL hostname
+- [ ] 1.4 Update `port` property to follow precedence: `HYDROLIX_HTTP_QUERY_PORT` > `HYDROLIX_PORT` > URL-derived (443/80) > hard default 8088
+- [ ] 1.5 Update `secure` property to follow precedence: `HYDROLIX_HTTP_QUERY_SECURE` > `HYDROLIX_SECURE` > URL-derived (scheme == "https") > hard default True
+- [ ] 1.6 Rename `api_host` property to `version_api_host` with precedence: `HYDROLIX_VERSION_API_HOST` > `HYDROLIX_API_HOST` > URL hostname > fallback to `host`
+- [ ] 1.7 Rename `api_port` property to `version_api_port` with precedence: `HYDROLIX_VERSION_API_PORT` > `HYDROLIX_API_PORT` > URL-derived > `443 if secure else 80`
+- [ ] 1.8 Add new `version_api_secure` property with precedence: `HYDROLIX_VERSION_API_SECURE` > resolved `secure`
+- [ ] 1.9 Update `_validate_required_vars` to accept any of `HYDROLIX_URL` / `HYDROLIX_HOST` / `HYDROLIX_HTTP_QUERY_HOST`; require `HYDROLIX_URL` specifically when transport is http/sse
+- [ ] 1.10 Update `HydrolixConfig` class docstring to document new vars, precedence, and requirements
+
+## 2. Deprecation Detection and Messaging (mcp_env.py)
+
+- [ ] 2.1 Add `ALIAS_RENAMES` dict and `DEPRECATED_ALIASES` tuple at module level
+- [ ] 2.2 Add `_detect_deprecated_aliases()` helper returning list of set deprecated var names
+- [ ] 2.3 Add `_classify_deprecation(aliases)` helper returning `"external"`, `"internal"`, or `None` based on `HYDROLIX_NAME`
+- [ ] 2.4 Add `_external_deprecation_warned` and `_internal_deprecation_warned` module-level sentinels
+- [ ] 2.5 Define `EXTERNAL_DEPRECATION_MESSAGE` and `INTERNAL_DEPRECATION_MESSAGE` module-level constants
+- [ ] 2.6 Emit external WARNING log from `HydrolixConfig.__init__` (after `_validate_required_vars`), guarded by sentinel
+- [ ] 2.7 Store `self._deprecated_aliases` and `self._deprecation_audience` as instance state; expose as readable properties
+- [ ] 2.8 Add `deprecation_notice` property returning the external message string or `None`
+
+## 3. FastMCP Wiring and Version-Gated Internal Log (mcp_server.py)
+
+- [ ] 3.1 Pass `instructions=HYDROLIX_CONFIG.deprecation_notice` to `FastMCP()` constructor
+- [ ] 3.2 Update `/version` probe URL construction: `api_host` -> `version_api_host`, `api_port` -> `version_api_port`, scheme source from `secure` -> `version_api_secure`
+- [ ] 3.3 Add `_maybe_emit_internal_deprecation_log(parsed_version)` helper with version >= 6.1 gate, audience check, and sentinel guard
+- [ ] 3.4 Call `_maybe_emit_internal_deprecation_log` from `_check_parameterized_query_support` after successful version parse
+
+## 4. Tests -- URL Parsing and Precedence (tests/test_mcp_env.py)
+
+- [ ] 4.1 Add env isolation fixture (`autouse=True`) clearing all `HYDROLIX_*` env vars
+- [ ] 4.2 Test URL parsing happy paths (https, http, IPv6, userinfo, trailing slash, empty path, port-ignored)
+- [ ] 4.3 Test URL validation errors (missing scheme, unsupported scheme, no hostname, empty-after-strip)
+- [ ] 4.4 Test external sufficiency: `HYDROLIX_URL` alone resolves all six properties correctly
+- [ ] 4.5 Test external sufficiency with split ports
+- [ ] 4.6 Test full precedence chain for each of host/port/secure (new > alias > URL > default)
+- [ ] 4.7 Test full precedence chain for version_api_host/version_api_port
+- [ ] 4.8 Test `version_api_secure` inheritance and explicit override scenarios
+- [ ] 4.9 Test backwards compatibility: `HYDROLIX_HOST` alone preserves pre-change defaults bit-for-bit
+- [ ] 4.10 Test in-cluster post-migration shape (all new vars)
+- [ ] 4.11 Test in-cluster transition shape (all deprecated aliases)
+- [ ] 4.12 Test connection target validation errors (none set, transport-specific requirement)
+
+## 5. Tests -- Deprecation Classification and Messaging (tests/test_mcp_env_deprecation.py)
+
+- [ ] 5.1 Add env isolation fixture clearing all `HYDROLIX_*` vars and resetting both sentinels
+- [ ] 5.2 Test `_detect_deprecated_aliases()` for single, multiple, all, and none cases
+- [ ] 5.3 Test `_classify_deprecation()` for external, internal, none, and partial-migration cases
+- [ ] 5.4 Test external WARNING log fires once at `HydrolixConfig.__init__`; no duplicate on second construction
+- [ ] 5.5 Test internal audience does NOT trigger startup WARNING log
+- [ ] 5.6 Test `deprecation_notice` returns message for external, `None` for internal, `None` for no-deprecation
+- [ ] 5.7 Test no-deprecation path: only new vars set (with or without `HYDROLIX_NAME`) -> no log, notice is `None`
+
+## 6. Tests -- Version-Gated Internal Deprecation (tests/test_internal_deprecation_version_gate.py)
+
+- [ ] 6.1 Add fixture resetting `_internal_deprecation_warned` sentinel and `_parameterized_queries_supported` cache
+- [ ] 6.2 Test internal audience + version 6.1.0 -> ERROR log fires exactly once
+- [ ] 6.3 Test internal audience + versions 6.2.0, 7.0.0, 6.1.0-5-gabcdef12 -> ERROR log fires
+- [ ] 6.4 Test internal audience + versions 6.0.9, 5.12.0, 5.0.0 -> no log
+- [ ] 6.5 Test internal audience + probe HTTP error -> no log; subsequent success with 6.1 -> log fires
+- [ ] 6.6 Test internal audience + non-200 response -> no log
+- [ ] 6.7 Test internal audience + unparseable body -> no log
+- [ ] 6.8 Test external audience + any version response -> no log from probe path
+- [ ] 6.9 Test no-deprecation + any version response -> no log from probe path
+
+## 7. Update Existing Tests (tests/test_parameterized_queries.py)
+
+- [ ] 7.1 Rename mock attribute `api_host` -> `version_api_host` in all probe-path tests
+- [ ] 7.2 Rename mock attribute `api_port` -> `version_api_port` in all probe-path tests
+- [ ] 7.3 Audit `mock_config.secure` usage in probe path and switch to `mock_config.version_api_secure` where it drives the probe scheme
+
+## 8. Documentation (README.md)
+
+- [ ] 8.1 Document `HYDROLIX_URL` as primary config var with external sufficiency note
+- [ ] 8.2 Document `HYDROLIX_HTTP_QUERY_HOST/PORT/SECURE` and `HYDROLIX_VERSION_API_HOST/PORT/SECURE` as endpoint overrides
+- [ ] 8.3 Mark five deprecated vars with migration guidance for both audiences
+- [ ] 8.4 Update minimal out-of-cluster example to use `HYDROLIX_URL`
+- [ ] 8.5 Update "Required Variables" note with the three-option requirement and transport-specific rule


### PR DESCRIPTION
## What does this PR do?

Introduces `HYDROLIX_URL` as the canonical "cluster public URL" input for mcp-hydrolix and adds a new three-layer config model with clear separation between cluster identity and endpoint overrides. This is a spec/design-only PR.

**Config model introduced:**

| Layer | Variables | Purpose |
|---|---|---|
| 1: Cluster identity | `HYDROLIX_URL` | Canonical public URL; sufficient for all external deployments |
| 2: HTTP query override | `HYDROLIX_HTTP_QUERY_HOST/PORT/SECURE` | Override ClickHouse HTTP query endpoint (in-cluster use) |
| 3: Version-API override | `HYDROLIX_VERSION_API_HOST/PORT/SECURE` | Override `/version` REST probe endpoint (in-cluster use) |

**Key decisions documented:**
- Four-tier precedence chain: explicit new var > deprecated alias > URL-derived > hard default
- Audience-aware deprecation messaging: external operators get a startup WARNING + LLM-visible FastMCP `instructions` advisory; internal (o6r-managed) pods get a version-gated ERROR log (>= 6.1) that never reaches the LLM
- `HYDROLIX_URL` is required for `http`/`sse` transport (scoped breaking change — no known extant external remote deployments)

**Motivation:** Upcoming OAuth work needs the cluster's canonical public URL for issuer validation and RFC 9728 resource metadata — neither is derivable from an internal k8s service hostname like `query-head`.

## Does this PR meet the acceptance criteria?

* [x] Documentation created/updated — `design.md`, `proposal.md`, `spec.md`, `tasks.md` added under `openspec/changes/hydrolix-url-config-collapse/`
* [ ] Tests added for this feature/bug — N/A for spec phase; test tasks tracked in `tasks.md` sections 4–7
* [x] Does this change request have any security impacts? — No direct security impact; the `HYDROLIX_URL` requirement for http/sse transport is a prerequisite for the OAuth security work in HDX-11442/HDX-11443

## Testing

This PR contains only spec/design documents. No runtime behavior changes. Reviewers should validate:

- [ ] The three-layer config model (identity vs. override) makes sense for all three deployment shapes (in-cluster, out-of-cluster, local/stdio)
- [ ] The four-tier precedence chain is correct and handles all transition cases
- [ ] The scoped breaking change assumption (no extant external remote deployments) is accurate
- [ ] The audience-detection heuristic (`HYDROLIX_NAME` presence) is acceptable
- [ ] The version gate (>= 6.1) for the internal deprecation log is correct
- [ ] The 82 implementation tasks in `tasks.md` are complete and correctly ordered