### PR TITLE
[IL] [MCP] [AIKIDO] Bump fastmcp to >=3.3.0,<3.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 license-files = ["LICENSE"]
 requires-python = ">=3.13"
 dependencies = [
-    "fastmcp>=3.0.2,<3.3",
+    "fastmcp>=3.3.0,<3.4",
     "python-dotenv>=1.1,<1.3",
     "clickhouse-connect>=0.15,<0.16",
     "truststore>=0.10",

--- a/uv.lock
+++ b/uv.lock
@@ -444,12 +444,47 @@ wheels = [
 
 [[package]]
 name = "fastmcp"
-version = "3.2.0"
+version = "3.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "fastmcp-slim", extra = ["client", "server"] },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/b8/aff9378edc9438916ce5f06ac31bc1d60dd99e1a82411e186f1c38e20a8b/fastmcp-3.3.0.tar.gz", hash = "sha256:48c7fffdb6865cb9658ac02c2ff589caaaa3cd68e2cc37ed51402fa46e46c2eb", size = 28804871, upload-time = "2026-05-15T02:04:59.357Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/bd/4f21d58764e1f1e1237e29bc58bb1b5863fde2297796c8e96301d334fe2d/fastmcp-3.3.0-py3-none-any.whl", hash = "sha256:e6b1dc391a9fcc4b6a7f0bb7c2481d1aac8d03eefe818908c69909795a39d51b", size = 7903, upload-time = "2026-05-15T02:05:02.24Z" },
+]
+
+[[package]]
+name = "fastmcp-slim"
+version = "3.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "platformdirs" },
+    { name = "pydantic", extra = ["email"] },
+    { name = "pydantic-settings" },
+    { name = "python-dotenv" },
+    { name = "rich" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/db/6e/f4ba7d4f5d586ee85b7e2dd4feff89112de0e4cedc6a5fda794adb6b99c2/fastmcp_slim-3.3.0.tar.gz", hash = "sha256:56fd0077226b8dbf0bba253f9baaad5d97a3f74eb62750d6997128486b91b0ba", size = 567972, upload-time = "2026-05-15T02:04:34.015Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/36/fa34dd253426e03e4f68918ca700758a22f3600fb6d4dc5a260b3d152c82/fastmcp_slim-3.3.0-py3-none-any.whl", hash = "sha256:7478c5220e06e5ff4f9cb5270e46c6b6d0f44ec0d79372a572b0a71195baa69a", size = 739366, upload-time = "2026-05-15T02:04:32.528Z" },
+]
+
+[package.optional-dependencies]
+client = [
+    { name = "authlib" },
+    { name = "exceptiongroup" },
+    { name = "httpx" },
+    { name = "mcp" },
+    { name = "opentelemetry-api" },
+    { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
+]
+server = [
     { name = "authlib" },
     { name = "cyclopts" },
     { name = "exceptiongroup" },
+    { name = "griffelib" },
     { name = "httpx" },
     { name = "jsonref" },
     { name = "jsonschema-path" },
@@ -457,21 +492,14 @@ dependencies = [
     { name = "openapi-pydantic" },
     { name = "opentelemetry-api" },
     { name = "packaging" },
-    { name = "platformdirs" },
     { name = "py-key-value-aio", extra = ["filetree", "keyring", "memory"] },
-    { name = "pydantic", extra = ["email"] },
     { name = "pyperclip" },
-    { name = "python-dotenv" },
+    { name = "python-multipart" },
     { name = "pyyaml" },
-    { name = "rich" },
     { name = "uncalled-for" },
     { name = "uvicorn" },
     { name = "watchfiles" },
     { name = "websockets" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d0/32/4f1b2cfd7b50db89114949f90158b1dcc2c92a1917b9f57c0ff24e47a2f4/fastmcp-3.2.0.tar.gz", hash = "sha256:d4830b8ffc3592d3d9c76dc0f398904cf41f04910e41a0de38cc1004e0903bef", size = 26318581, upload-time = "2026-03-30T20:25:37.692Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4f/67/684fa2d2de1e7504549d4ca457b4f854ccec3cd3be03bd86b33b599fbf58/fastmcp-3.2.0-py3-none-any.whl", hash = "sha256:e71aba3df16f86f546a4a9e513261d3233bcc92bef0dfa647bac3fa33623f681", size = 705550, upload-time = "2026-03-30T20:25:35.499Z" },
 ]
 
 [[package]]
@@ -494,6 +522,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5f/18/238d7021d151bdab868f23433817b027dd759135202f4dfce0670d1230ca/google_auth-2.50.0.tar.gz", hash = "sha256:f35eafb191195328e8ce10a7883970877e7aeb49c2bfaa54aa0e394316d353d0", size = 336523, upload-time = "2026-04-30T21:19:29.659Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/37/cf/4880c2137c14280b2f59975cdf12cc442bc0ae1f9ea473a26eaa0c146786/google_auth-2.50.0-py3-none-any.whl", hash = "sha256:04382175e28b94f49694977f0a792688b59a668def1499e9d8de996dc9ce5b15", size = 246495, upload-time = "2026-04-30T21:19:27.664Z" },
+]
+
+[[package]]
+name = "griffelib"
+version = "2.0.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/82/74f4a3310cdabfbb10da554c3a672847f1ed33c6f61dd472681ce7f1fe67/griffelib-2.0.2.tar.gz", hash = "sha256:3cf20b3bc470e83763ffbf236e0076b1211bac1bc67de13daf494640f2de707e", size = 166461, upload-time = "2026-03-27T11:34:51.091Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/11/8c/c9138d881c79aa0ea9ed83cbd58d5ca75624378b38cee225dcf5c42cc91f/griffelib-2.0.2-py3-none-any.whl", hash = "sha256:925c857658fb1ba40c0772c37acbc2ab650bd794d9c1b9726922e36ea4117ea1", size = 142357, upload-time = "2026-03-27T11:34:46.275Z" },
 ]
 
 [[package]]
@@ -849,7 +886,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "clickhouse-connect", specifier = ">=0.15,<0.16" },
-    { name = "fastmcp", specifier = ">=3.0.2,<3.3" },
+    { name = "fastmcp", specifier = ">=3.3.0,<3.4" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27,<0.29" },
     { name = "kubernetes", marker = "extra == 'dev'", specifier = ">=30,<32" },
     { name = "mcp-clickhouse", marker = "extra == 'dev'", specifier = "==0.1.13" },


### PR DESCRIPTION
What does this PR do?
-----------------------

Bumps `fastmcp` from `>=3.0.2,<3.3` (resolved 3.2.0) to `>=3.3.0,<3.4` (resolves 3.3.0) to address five Aikido-reported vulnerabilities:

| Aikido ID | Severity | Fixed in |
|---|---|---|
| AIKIDO-2026-10825 | High | 3.3.0 |
| AIKIDO-2026-10824 | High | 3.3.0 |
| AIKIDO-2026-10826 | High | 3.3.0 |
| AIKIDO-2026-10734 | Medium | 3.2.4 |
| AIKIDO-2026-10735 | Medium | — |

Worst-case impacts per Aikido: phishing via open-redirect, authorization bypass, identity hiding / restriction bypass.

**Pinning choice.** Aikido's auto-suggestion was `fastmcp==3.3.0`, but every other dep in `pyproject.toml` uses a range pin (`pyjwt>=2.10,<2.13`, `clickhouse-connect>=0.15,<0.16`, etc.), so this PR uses `>=3.3.0,<3.4` for consistency. That also lets future 3.3.x patch releases be picked up automatically while still blocking the next minor bump.

Does this PR meet the acceptance criteria?
--------------------------------------------

* [x] Documentation created/updated — N/A (dependency bump only)
* [x] Tests added for this feature/bug — N/A; ran the existing unit suite, no regressions
* [x] Does this change request have any security impacts? — Yes, this PR *fixes* five reported vulnerabilities. No new attack surface introduced.

Release Notes
---------------------------------------------------

* Major changes:
    *
* Minor changes:
    *
* Bugfixes:
    *
* Issues Closed:
    *
* Security impacts identified:
    * Bumps fastmcp to 3.3.0+ to fix AIKIDO-2026-10825 / 10824 / 10826 (high), 10734 / 10735 (medium)

Testing
--------------------------------------------

* `uv lock` → resolved 116 packages, fastmcp updated 3.2.0 → 3.3.0 (plus transitive additions: fastmcp-slim 3.3.0, griffelib 2.0.2)
* `uv sync --extra dev` → clean
* `uv run pytest tests/ --ignore=tests/e2e -m "not integration_clickhouse and not end_to_end"` → 211 passed, 33 deselected
* `uv run ruff check mcp_hydrolix/ tests/` → All checks passed
* `uv run ruff format --check mcp_hydrolix/ tests/` → clean
* Integration tests (`integration_clickhouse`) and e2e tests not run — need live ClickHouse / k8s

🤖 Generated with [Claude Code](https://claude.com/claude-code)