### PR TITLE
[IL] [OpenSpec] Extend MODIFIED hardening to REMOVED + fix delta-count + standardize placeholder casing

### DIFF
--- a/openspec/schemas/interactive-spec-led/schema.yaml
+++ b/openspec/schemas/interactive-spec-led/schema.yaml
@@ -202,7 +202,7 @@ artifacts:
       - **ADDED Requirements** — net-new requirements.
       - **MODIFIED Requirements** — changed behavior. (See HARD RULE below.)
       - **REMOVED Requirements** — MUST include **Reason** and **Migration**
-        lines.
+        lines. (See HARD RULE below — same header-match risk as MODIFIED.)
 
       OpenSpec defines exactly these three delta operations (`ADDED`,
       `MODIFIED`, `REMOVED`). Other operation names (including `RENAMED`)
@@ -247,11 +247,12 @@ artifacts:
          the body and / or scenarios to reflect the new behavior.
 
       HARD RULE (this is the single highest-cost silent failure in OpenSpec):
-        The header line `### Requirement: <Name>` in your MODIFIED block
-        MUST be byte-identical (whitespace-insensitive) to the existing
-        header in `openspec/specs/<capability>/spec.md`. A mismatch fails
-        the modification at archive and silently loses your edits. After
-        pasting, diff your header against the source.
+        The header line `### Requirement: <Name>` in your MODIFIED or REMOVED
+        block MUST be byte-identical (whitespace-insensitive) to the existing
+        header in `openspec/specs/<capability>/spec.md`. A mismatch fails the
+        operation at archive — MODIFIED silently loses your edits; REMOVED
+        silently leaves the requirement in place — and no error is surfaced.
+        After pasting, diff your header against the source.
 
       Style:
       - Terse, requirement-style (RFC 2119 / BCP 14 keywords), testable. Each scenario should be implementable
@@ -392,12 +393,12 @@ artifacts:
         where `<requirement-slug>` is the kebab-case slug of the parent
         requirement's heading.
       - Name the SCENARIO-specific test function in its `verify:` clause,
-        of the form `pytest -q tests/test_<cap_folder>.py::test_<scenario_slug>`
+        of the form `pytest -q tests/test_<capability-folder>.py::test_<scenario-slug>`
         (apply the slug rule to the scenario heading, then `-` → `_` so
         the result is a valid Python identifier).
       - So a requirement with N scenarios produces N test tasks, all
         citing the same requirement but each verifying a distinct
-        `test_<scenario_slug>` function.
+        `test_<scenario-slug>` function.
       A scenario without a matching test task is a generation defect and
       apply pre-flight will STOP (step 4, scenario-coverage check).
 
@@ -501,18 +502,21 @@ apply:
        - For each `#### Scenario:` heading in specs, derive its
          scenario-slug via the slug rule.
        - Confirm tasks.md contains at least one task whose `verify:`
-         clause names the test function `test_<scenario_slug_underscored>`
-         (with `-` → `_`). If any scenario has no matching `verify:`,
-         STOP. This catches the case where ONE bundled test task
-         appears to cover multiple scenarios under one requirement.
-    5. MODIFIED-header byte-match check (the single highest-cost silent
-       failure — see specs HARD RULE):
+         clause names the test function `test_<scenario-slug>`
+         (with `-` → `_` so it's a valid Python identifier). If any
+         scenario has no matching `verify:`, STOP. This catches the
+         case where ONE bundled test task appears to cover multiple
+         scenarios under one requirement.
+    5. MODIFIED/REMOVED-header byte-match check (the single highest-cost
+       silent failure — see specs HARD RULE):
        - For each `### Requirement:` heading under a `## MODIFIED
-         Requirements` block in any `specs/<cap>/spec.md` in this change,
-         read the corresponding header in `openspec/specs/<cap>/spec.md`
-         (the existing archived spec). Confirm the two heading lines are
-         byte-identical (whitespace-insensitive). If any mismatch, STOP
-         — the modification would silently drop at archive time.
+         Requirements` OR `## REMOVED Requirements` block in any
+         `specs/<cap>/spec.md` in this change, read the corresponding
+         header in `openspec/specs/<cap>/spec.md` (the existing archived
+         spec). Confirm the two heading lines are byte-identical
+         (whitespace-insensitive). If any mismatch, STOP — the operation
+         would silently drop at archive (MODIFIED loses your edits;
+         REMOVED leaves the requirement in place).
     6. Binding-source review:
        - For each design Decision, confirm its **Binding** line is
          present, non-empty, and contains no placeholder text (e.g.

--- a/openspec/schemas/interactive-spec-led/templates/spec.md
+++ b/openspec/schemas/interactive-spec-led/templates/spec.md
@@ -17,17 +17,19 @@
   - `- **THEN** <outcome>` — the assertion.
   - `- **AND** <additional>` — continues whichever block it follows.
 
-  HARD RULE for MODIFIED requirements:
+  HARD RULE for MODIFIED and REMOVED requirements:
     Header line MUST be byte-identical (whitespace-insensitive) to the
-    existing header in openspec/specs/<cap>/spec.md. Mismatch silently
-    loses your edits at archive time. Diff after pasting.
+    existing header in openspec/specs/<cap>/spec.md. Mismatch fails the
+    operation at archive time — MODIFIED silently loses your edits;
+    REMOVED silently leaves the requirement in place — no error is
+    surfaced. Diff after pasting.
 
   Style: use RFC 2119 / BCP 14 keywords (MUST, SHALL, SHOULD, MAY and
   negatives) with their RFC 2119 meanings. PREFER MUST / SHALL for binding
   requirements; SHOULD / MAY are valid for recommendations and permissions.
   Every requirement has ≥ 1 scenario.
 
-  This template shows all four delta sections. Delete the sections that
+  This template shows all three delta sections. Delete the sections that
   don't apply to this change rather than commenting them out.
 
   Tracing explore Decisions: add `<!-- settle: explore/<slug> -->` on its
@@ -41,7 +43,7 @@
   - Requirement with zero scenarios.
   - Title-Case-With-Spaces-Wrong-Form (e.g. `kebab-case` or `PascalCase`
     requirement headings; OpenSpec archive expects Title Case With Spaces).
-  - MODIFIED block header that doesn't byte-match the existing spec.
+  - MODIFIED or REMOVED block header that doesn't byte-match the existing spec.
 -->
 
 *<one-line summary, ≤ 25 words: what this capability covers>*

--- a/openspec/schemas/interactive-spec-led/templates/tasks.md
+++ b/openspec/schemas/interactive-spec-led/templates/tasks.md
@@ -17,13 +17,13 @@
     cites the PARENT requirement (not the scenario).
   - `verify:` names the SCENARIO-specific test function.
   A requirement with N scenarios produces N test tasks, each verifying
-  a distinct `test_<scenario_slug>` function. Apply pre-flight rejects
+  a distinct `test_<scenario-slug>` function. Apply pre-flight rejects
   scenarios with no matching verify clause.
 
   Test naming convention (for verify: clauses):
-  - File: `tests/test_<capability_folder>.py` (apply slug rule to the
+  - File: `tests/test_<capability-folder>.py` (apply slug rule to the
     capability folder name, then `-` → `_` for the filename).
-  - Function: `test_<scenario_slug>` — apply slug rule to the scenario
+  - Function: `test_<scenario-slug>` — apply slug rule to the scenario
     heading text, then `-` → `_` (Python identifiers can't contain `-`).
     So scenario `Parses Valid Url` → `parses-valid-url` (kebab slug) →
     `test_parses_valid_url` (test function).
@@ -66,7 +66,7 @@
 ## 2. <phase name>
 
 - [ ] 2.1 <task> [implements: explore/<decision-slug>] — verify: <check>
-- [ ] 2.2 Add test for scenario `<Title Case Scenario Name>` [implements: <capability-folder>/<requirement-slug>, meta/tests] — verify: `pytest -q tests/test_<capability_folder>.py::test_<scenario_slug>` green (function name = slug of the scenario heading; one test task per scenario, all citing the same requirement-slug)
+- [ ] 2.2 Add test for scenario `<Title Case Scenario Name>` [implements: <capability-folder>/<requirement-slug>, meta/tests] — verify: `pytest -q tests/test_<capability-folder>.py::test_<scenario-slug>` green (function name = slug of the scenario heading; one test task per scenario, all citing the same requirement-slug)
 
 ## 3. <phase name>
 


### PR DESCRIPTION
What does this PR do?
-----------------------

Three follow-up tightenings on the `interactive-spec-led` workflow merged in #104. All edits are to schema/templates only — no code, no behavior change beyond what an `/opsx:verify` run would catch.

### 1. REMOVED-header byte-match (the real bug)

The HARD RULE prose (in the specs `instruction:` block) and `apply` step 5 only guarded `## MODIFIED Requirements`, but `openspec archive` resolves both `MODIFIED` and `REMOVED` by header text and silently no-ops on drift in *either* case. A drifted header on `## REMOVED Requirements` quietly leaves the requirement in place — no error surfaced, nothing to debug.

This PR extends:
- The HARD RULE block in `schema.yaml:249-255` to cover both MODIFIED and REMOVED.
- `apply` step 5 in `schema.yaml:510-519` to iterate `## MODIFIED Requirements` AND `## REMOVED Requirements` blocks, byte-matching both.
- The corresponding HARD RULE comment in `templates/spec.md`.
- The anti-pattern bullet in `templates/spec.md`.
- The delta-ops list bullet in `schema.yaml:201-205` (parallel `(See HARD RULE below…)` pointer on the REMOVED bullet).

**Heads-up for in-flight authors.** Once this lands, any change that uses `## REMOVED Requirements` will get its headers byte-matched against the archived spec by `/opsx:verify` step 5. If a REMOVED header has drifted, the check STOPs rather than silently succeeding (as it would have on `main` today). I checked: no existing change in `openspec/changes/` uses REMOVED yet, so nothing breaks retroactively — but worth a heads-up for anyone with a change already mid-authoring.

I raised this as an inline review comment on #104 ([discussion_r3283581522](https://github.com/hydrolix/mcp-hydrolix/pull/104#discussion_r3283581522)) before that PR merged; this is the follow-up fix.

### 2. spec.md template "all four delta sections" → "three"

Leftover wording from upstream OpenSpec which has four ops (ADDED/MODIFIED/REMOVED/RENAMED). The IL workflow rejected `RENAMED` in #104 (silently ignored by `openspec archive`); only three delta sections exist now. One-word fix in `templates/spec.md:32`.

### 3. Placeholder casing standardized on kebab

The schema and `templates/tasks.md` were mixing two forms for the same field:
- Kebab + explicit `-` → `_` substitution rule: `<capability-folder>`, `<scenario-slug>`
- Pre-substituted snake: `<capability_folder>`, `<scenario_slug>`, `<scenario_slug_underscored>`

Both convey the same intent, but a reader sees three notations and may not realize they're identical. Standardize on kebab everywhere — the `-` → `_` substitution rule is already documented next to each use.

Affected lines:
- `schema.yaml:396, 401, 505` (was using snake or `_underscored`)
- `templates/tasks.md:20, 24, 26, 69`

Does this PR meet the acceptance criteria?
--------------------------------------------

* [x] Documentation created/updated — schema and template changes only
* [x] Tests added for this feature/bug — N/A; no production code changes. YAML parses cleanly (`uv run python -c "import yaml; yaml.safe_load(open('openspec/schemas/interactive-spec-led/schema.yaml'))"` → OK)
* [x] Does this change request have any security impacts? — None

Release Notes
---------------------------------------------------

* Major changes:
    *
* Minor changes:
    * OpenSpec workflow: REMOVED-header byte-match now enforced at `/opsx:verify` and called out in HARD RULE prose (same protection MODIFIED already had)
    * OpenSpec workflow: kebab-case placeholders standardized across schema + tasks template
* Bugfixes:
    *
* Issues Closed:
    *
* Security impacts identified:
    *

Testing
--------------------------------------------

* `python -c "import yaml; yaml.safe_load(open('openspec/schemas/interactive-spec-led/schema.yaml'))"` → parses
* `grep '<capability_folder>\|<scenario_slug>\|<cap_folder>\|scenario_slug_underscored' openspec/` → none remain
* Visual diff review — every MODIFIED-only reference that's about the byte-match risk now also mentions REMOVED; references that aren't about the byte-match (e.g. "use MODIFIED to rename a scenario") correctly remain MODIFIED-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
