### PR TITLE
[IL] OpenSpec template self-review checklists + block ClickHouse PR target

### DIFF
--- a/.claude/hooks/block-clickhouse-pr.py
+++ b/.claude/hooks/block-clickhouse-pr.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""PreToolUse guard: block any Bash invocation that would open a PR against
+ClickHouse/mcp-clickhouse (the upstream fork parent of this repo).
+
+This repo is forked from ClickHouse/mcp-clickhouse, so `gh pr create` without
+an explicit `--repo` defaults to the upstream parent. PRs from this repo MUST
+target hydrolix/mcp-hydrolix. This hook is the hard backstop — it fires before
+the Bash tool runs and cannot be bypassed by permission mode (auto, accept-
+edits, bypass-permissions all still run PreToolUse hooks).
+
+Exit codes:
+  0 — allow
+  2 — block, emit message to Claude on stderr
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+
+FORBIDDEN_REPO = "clickhouse/mcp-clickhouse"
+REQUIRED_REPO = "hydrolix/mcp-hydrolix"
+
+
+def is_pr_create(command: str) -> bool:
+    return bool(re.search(r"(?:^|[;&|`$(\s])gh\s+pr\s+create\b", command))
+
+
+def extract_repo_flag(command: str) -> str | None:
+    m = re.search(r"(?:--repo|-R)(?:[=\s]+)(['\"]?)([^'\"\s;|&]+)\1", command)
+    return m.group(2).lower() if m else None
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        return 0
+
+    if payload.get("tool_name") != "Bash":
+        return 0
+
+    command = (payload.get("tool_input") or {}).get("command", "")
+    if not isinstance(command, str) or not command:
+        return 0
+
+    if not is_pr_create(command):
+        return 0
+
+    repo = extract_repo_flag(command)
+
+    if repo is None:
+        sys.stderr.write(
+            "BLOCKED: `gh pr create` without `--repo` is forbidden in this repo.\n"
+            f"This repo is a fork of {FORBIDDEN_REPO}; the default PR target is the\n"
+            f"upstream parent, NOT {REQUIRED_REPO}. You must pass `--repo {REQUIRED_REPO}`\n"
+            "explicitly. See .claude/hooks/block-clickhouse-pr.py for the rule.\n"
+        )
+        return 2
+
+    if repo == FORBIDDEN_REPO:
+        sys.stderr.write(
+            f"BLOCKED: refusing to open a PR against {FORBIDDEN_REPO}.\n"
+            f"This repo's PRs must target {REQUIRED_REPO}. Re-run with\n"
+            f"`--repo {REQUIRED_REPO}`.\n"
+        )
+        return 2
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.claude/hooks/block-clickhouse-pr.py
+++ b/.claude/hooks/block-clickhouse-pr.py
@@ -1,12 +1,20 @@
 #!/usr/bin/env python3
-"""PreToolUse guard: block any Bash invocation that would open a PR against
+"""PreToolUse guard: block any invocation that would open a PR against
 ClickHouse/mcp-clickhouse (the upstream fork parent of this repo).
 
-This repo is forked from ClickHouse/mcp-clickhouse, so `gh pr create` without
-an explicit `--repo` defaults to the upstream parent. PRs from this repo MUST
-target hydrolix/mcp-hydrolix. This hook is the hard backstop — it fires before
-the Bash tool runs and cannot be bypassed by permission mode (auto, accept-
-edits, bypass-permissions all still run PreToolUse hooks).
+Covers two surfaces:
+
+1. Bash — `gh pr create` without `--repo`, or with `--repo`/`-R` pointing at
+   the upstream parent. Without `--repo`, `gh` defaults to the parent fork.
+
+2. MCP — any tool whose name ends in `create_pull_request` (github MCP
+   servers expose this; both the official `mcp__github__create_pull_request`
+   and the ECC plugin's `mcp__plugin_ecc_github__create_pull_request`
+   accept `owner`/`repo` parameters).
+
+PreToolUse hooks fire before the tool runs and cannot be bypassed by
+permission mode (default / auto / acceptEdits / bypassPermissions all run
+PreToolUse hooks).
 
 Exit codes:
   0 — allow
@@ -19,8 +27,10 @@ import json
 import re
 import sys
 
-FORBIDDEN_REPO = "clickhouse/mcp-clickhouse"
-REQUIRED_REPO = "hydrolix/mcp-hydrolix"
+FORBIDDEN_OWNER = "clickhouse"
+FORBIDDEN_REPO = "mcp-clickhouse"
+FORBIDDEN_SLUG = f"{FORBIDDEN_OWNER}/{FORBIDDEN_REPO}"
+REQUIRED_SLUG = "hydrolix/mcp-hydrolix"
 
 
 def is_pr_create(command: str) -> bool:
@@ -32,19 +42,10 @@ def extract_repo_flag(command: str) -> str | None:
     return m.group(2).lower() if m else None
 
 
-def main() -> int:
-    try:
-        payload = json.load(sys.stdin)
-    except Exception:
-        return 0
-
-    if payload.get("tool_name") != "Bash":
-        return 0
-
-    command = (payload.get("tool_input") or {}).get("command", "")
+def handle_bash(tool_input: dict) -> int:
+    command = tool_input.get("command", "")
     if not isinstance(command, str) or not command:
         return 0
-
     if not is_pr_create(command):
         return 0
 
@@ -53,19 +54,54 @@ def main() -> int:
     if repo is None:
         sys.stderr.write(
             "BLOCKED: `gh pr create` without `--repo` is forbidden in this repo.\n"
-            f"This repo is a fork of {FORBIDDEN_REPO}; the default PR target is the\n"
-            f"upstream parent, NOT {REQUIRED_REPO}. You must pass `--repo {REQUIRED_REPO}`\n"
+            f"This repo is a fork of {FORBIDDEN_SLUG}; the default PR target is the\n"
+            f"upstream parent, NOT {REQUIRED_SLUG}. You must pass `--repo {REQUIRED_SLUG}`\n"
             "explicitly. See .claude/hooks/block-clickhouse-pr.py for the rule.\n"
         )
         return 2
 
-    if repo == FORBIDDEN_REPO:
+    if repo == FORBIDDEN_SLUG:
         sys.stderr.write(
-            f"BLOCKED: refusing to open a PR against {FORBIDDEN_REPO}.\n"
-            f"This repo's PRs must target {REQUIRED_REPO}. Re-run with\n"
-            f"`--repo {REQUIRED_REPO}`.\n"
+            f"BLOCKED: refusing to open a PR against {FORBIDDEN_SLUG}.\n"
+            f"This repo's PRs must target {REQUIRED_SLUG}. Re-run with\n"
+            f"`--repo {REQUIRED_SLUG}`.\n"
         )
         return 2
+
+    return 0
+
+
+def handle_mcp_pr_create(tool_name: str, tool_input: dict) -> int:
+    owner = str(tool_input.get("owner", "")).lower()
+    repo = str(tool_input.get("repo", "")).lower()
+
+    if owner == FORBIDDEN_OWNER and repo == FORBIDDEN_REPO:
+        sys.stderr.write(
+            f"BLOCKED: refusing to open a PR against {FORBIDDEN_SLUG} via {tool_name}.\n"
+            f"This repo's PRs must target {REQUIRED_SLUG}. Re-call with\n"
+            f"owner='hydrolix', repo='mcp-hydrolix'.\n"
+        )
+        return 2
+
+    return 0
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:
+        return 0
+
+    tool_name = payload.get("tool_name", "")
+    tool_input = payload.get("tool_input") or {}
+    if not isinstance(tool_input, dict):
+        return 0
+
+    if tool_name == "Bash":
+        return handle_bash(tool_input)
+
+    if tool_name.startswith("mcp__") and tool_name.endswith("create_pull_request"):
+        return handle_mcp_pr_create(tool_name, tool_input)
 
     return 0
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,23 @@
+{
+  "permissions": {
+    "deny": [
+      "Bash(gh pr create *--repo ClickHouse/mcp-clickhouse*)",
+      "Bash(gh pr create *--repo=ClickHouse/mcp-clickhouse*)",
+      "Bash(gh pr create *-R ClickHouse/mcp-clickhouse*)",
+      "Bash(gh pr create *-R=ClickHouse/mcp-clickhouse*)"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/block-clickhouse-pr.py\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -17,6 +17,15 @@
             "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/block-clickhouse-pr.py\""
           }
         ]
+      },
+      {
+        "matcher": "mcp__.*create_pull_request",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "python3 \"$CLAUDE_PROJECT_DIR/.claude/hooks/block-clickhouse-pr.py\""
+          }
+        ]
       }
     ]
   }

--- a/.gitignore
+++ b/.gitignore
@@ -187,3 +187,6 @@ mcpb/manifest.json
 mcpb/pyproject.toml
 mcpb/icon.png
 dist/*.mcpb
+
+# Claude Code writes per-user permission overrides here — never commit.
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,25 @@
+# Claude project rules — mcp-hydrolix
+
+## PRs MUST target hydrolix/mcp-hydrolix
+
+This repository is a fork of `ClickHouse/mcp-clickhouse`. Because of that, `gh
+pr create` without an explicit `--repo` flag defaults to opening a PR against
+the **upstream parent** (`ClickHouse/mcp-clickhouse`), not this repo. That is
+never what we want.
+
+**Rule:** every `gh pr create` invocation in this repo MUST include
+`--repo hydrolix/mcp-hydrolix` explicitly. Never open a PR against
+`ClickHouse/mcp-clickhouse`.
+
+This rule applies in every permission mode — `default`, `auto`, `acceptEdits`,
+`bypassPermissions`, anything else. A `PreToolUse` Bash hook at
+`.claude/hooks/block-clickhouse-pr.py` enforces it programmatically (exit code
+2 = hard block), and `.claude/settings.json` carries deny rules as a second
+layer. Do not disable, weaken, or work around these guards.
+
+## Asking before opening PRs
+
+Opening a pull request is a shared-state action (visible to others, hard to
+undo cleanly). Do not run `gh pr create` unless the user has explicitly asked
+for a PR in this turn. Committing locally and pushing to a branch is fine when
+the user asks; opening the PR is a separate authorization.

--- a/openspec/schemas/interactive-spec-led/templates/design.md
+++ b/openspec/schemas/interactive-spec-led/templates/design.md
@@ -68,3 +68,28 @@ mechanical rename, doc-only, dependency bump with no API surface change.
 MUST be operator-confirmed during explore (cite the explore Decision or
 No Ambiguity block).
 -->
+
+<!--
+BEFORE FINALIZING — run every check.
+
+Syntactic (grep / wc):
+- [ ] No code fences (```) in any Decision block (shell snippets belong
+      in tasks.md `verify:` clauses, not here)
+- [ ] No `^from .* import` lines (exact import statements belong in tasks
+      or implementation, not design)
+- [ ] `wc -w < design.md` ≤ 600
+- [ ] Every `### Decision: <slug>` block has all four lines: Choice, Why,
+      Alternatives, Binding
+- [ ] Every `explore/<slug>` referenced in a Why line exists as a
+      `### Decision: <slug>` in `explore.md`
+
+Re-classification (re-read each Decision and ask):
+- [ ] For each Decision Choice line: "is this an architecture-level
+      choice, or a line-level implementation detail?" If the latter
+      (enumerated placeholder vocabulary, exact code, specific class
+      names beyond the one chokepoint), generalize the prose — the
+      specifics belong in tasks.md.
+- [ ] For each Binding line: "is this a constraint future code must
+      honor, or just a restatement of the Choice?" If the latter,
+      sharpen to a testable constraint or delete the line.
+-->

--- a/openspec/schemas/interactive-spec-led/templates/explore.md
+++ b/openspec/schemas/interactive-spec-led/templates/explore.md
@@ -80,3 +80,28 @@ confirmation cited.
 <!-- Bullets, "<assumption> — <what breaks if false>". Write "*none*" if not applicable. -->
 
 - <assumption> — <what breaks if false>
+
+<!--
+BEFORE FINALIZING — run every check.
+
+Syntactic (grep):
+- [ ] Every `### Decision: <slug>` block has all four lines: Question,
+      Answer, Rationale, Affects
+- [ ] No `Affects:` line contains placeholder text (e.g. `<artifact +
+      section>`, `<Title Case Name>`); every Affects names a real file
+      + section
+- [ ] Exactly one of `## Decisions` or `## No Ambiguity` is present
+      (never both)
+- [ ] If `## No Ambiguity` is used, it cites a specific operator prompt
+      or message that established no ambiguity
+
+Re-classification (re-read each Decision and ask):
+- [ ] For each Question bullet under `## Questions Asked`: "was this
+      ACTUALLY put to the operator in the session transcript?" If not,
+      delete it — explore.md is an audit trail, not a notebook of
+      questions the model thought about. Items that surfaced later go
+      in design.md Open Questions instead.
+- [ ] For each Decision Answer: "is this what the operator actually
+      decided, or what I inferred they would have decided?" If the
+      latter, demote to design.md as an Assumption or Open Question.
+-->

--- a/openspec/schemas/interactive-spec-led/templates/proposal.md
+++ b/openspec/schemas/interactive-spec-led/templates/proposal.md
@@ -42,3 +42,23 @@
 <!-- One bullet each: affected code paths, public APIs, external dependencies, data migrations. -->
 
 - <impact>
+
+<!--
+BEFORE FINALIZING — run every check; the artifact is not done until each is satisfied.
+
+Syntactic (grep / wc):
+- [ ] `grep -E 'LOC|line[s]? of code|~[0-9]+ lines|≈ ?[0-9]+ lines'` returns nothing
+- [ ] No backtick-quoted env-var assignments (`FOO=bar`) anywhere
+- [ ] No code fences (```)
+- [ ] `wc -w < proposal.md` ≤ 300
+- [ ] What Changes bullet count ≤ 8
+- [ ] Every capability under `### New` has a corresponding `specs/<name>/spec.md` in this change
+
+Re-classification (re-read each bullet and ask):
+- [ ] For each What Changes bullet: "does this describe an observable
+      capability change, or how we implement it?" If implementation,
+      move to design.md Decisions and rewrite the bullet at capability level.
+- [ ] For each Impact bullet: "does this name what's touched (file/system),
+      or how it's changed (mechanism)?" If mechanism, simplify to the
+      file/system; the mechanism goes in design.md.
+-->

--- a/openspec/schemas/interactive-spec-led/templates/spec.md
+++ b/openspec/schemas/interactive-spec-led/templates/spec.md
@@ -97,3 +97,36 @@
   `Migration:` line pointing at the new name) PLUS `## ADDED Requirements`
   for the new name. OpenSpec recognizes only ADDED / MODIFIED / REMOVED.
 -->
+
+<!--
+BEFORE FINALIZING — run every check.
+
+Syntactic (grep):
+- [ ] `grep -nE '\b(should|may)\b' specs/<cap>/spec.md` returns nothing
+      (lowercase RFC 2119 keywords don't carry their RFC meaning; use
+      MUST/SHALL/SHOULD/MAY uppercase)
+- [ ] `grep -nE '^### Scenario:' specs/<cap>/spec.md` returns nothing
+      (3 hashtags silently parses as requirement body — scenarios MUST
+      use exactly 4 hashtags)
+- [ ] Every `### Requirement:` block contains at least one
+      `#### Scenario:` heading
+- [ ] Every `#### Scenario:` block contains both **WHEN** and **THEN**
+- [ ] Requirement headings are Title Case With Spaces (no kebab-case,
+      no PascalCase)
+- [ ] Every `<!-- settle: explore/<slug> -->` comment points to a
+      `### Decision: <slug>` that exists in `explore.md`
+
+For MODIFIED / REMOVED sections (skip if absent):
+- [ ] Each `### Requirement:` header is byte-identical (whitespace-
+      insensitive) to the existing header in
+      `openspec/specs/<cap>/spec.md` — diff after pasting; a mismatch
+      silently loses your edits at archive time
+
+Re-classification (re-read each Requirement and ask):
+- [ ] "Does this state WHAT the system shall do, or WHY we want it?"
+      Rationale and motivation belong in design.md, not in
+      requirement prose.
+- [ ] "Is this requirement testable as written?" If not — if a tester
+      couldn't write a pass/fail assertion from the prose alone —
+      sharpen the wording until they can.
+-->

--- a/openspec/schemas/interactive-spec-led/templates/tasks.md
+++ b/openspec/schemas/interactive-spec-led/templates/tasks.md
@@ -71,3 +71,30 @@
 ## 3. <phase name>
 
 - [ ] 3.1 <docs / migration / rollout task> [implements: meta/<kind>] — verify: <check>
+
+<!--
+BEFORE FINALIZING — run every check.
+
+Syntactic (grep):
+- [ ] Every task line contains `[implements: ` AND `verify:`
+- [ ] Every `[implements: <cap>/<req-slug>]` requirement-slug equals the
+      kebab-derived form of an actual `### Requirement:` heading in
+      `specs/<cap>/spec.md` (lowercase, spaces → `-`, strip `[^a-z0-9-]`)
+- [ ] Every `[implements: design/<slug>]` matches a `### Decision: <slug>`
+      in `design.md`
+- [ ] Every `[implements: explore/<slug>]` matches a `### Decision: <slug>`
+      in `explore.md`
+- [ ] Every `[implements: meta/<kind>]` uses a `<kind>` ∈ {tests, docs,
+      migration, rollout, tooling}
+- [ ] For every `#### Scenario:` in this change's specs, there is
+      EXACTLY ONE task here whose `verify:` clause names the
+      scenario-specific test function (`test_<scenario-slug>`)
+- [ ] Test function names in `verify:` clauses equal the scenario
+      heading run through the slug rule, then `-` → `_`
+
+Re-classification (re-read each task and ask):
+- [ ] "Does this task bundle multiple deliverables?" If yes, split it.
+- [ ] "Is `verify:` a concrete, runnable check (test name, command,
+      grep), or hand-wavy ('verify it works')?" Sharpen vague verifies
+      into something a reviewer can mechanically execute.
+-->


### PR DESCRIPTION
Two related improvements to LLM-driven workflow safety in this repo.

---

## 1. OpenSpec interactive-spec-led template self-review checklists

Append a `<!-- BEFORE FINALIZING -->` self-review block to each interactive-spec-led template (`proposal.md`, `design.md`, `explore.md`, `spec.md`, `tasks.md`). Existing template content is unchanged — appended-only.

### Two-tier approach

Each checklist combines two kinds of checks:

- **Syntactic** — deterministic `grep`/`wc` checks the authoring model can run mechanically (LOC mentions, stray code fences, RFC-2119 casing, scenario-heading depth, `[implements:` + `verify:` presence, etc.).
- **Re-classification** — deliberate re-reads that ask the model to reclassify each bullet/decision/requirement against the artifact's purpose (capability vs. mechanism, architecture-level vs. line-level, audit-trail vs. notebook). This forces a verbal chain-of-thought that leads to (pretty) reliable detection for plain-language violations (the kind of thing `grep` can't catch)

### Leak classes caught per template

- `proposal.md` — LOC counts, env-var assignments, code fences, mechanism in What Changes / Impact bullets, runaway bullet count.
- `design.md` — code fences and exact import lines in Decisions, missing four-line Decision structure, dangling `explore/<slug>` references, line-level details masquerading as Choice, vacuous Binding lines.
- `explore.md` — placeholder `Affects:` lines, mixing `## Decisions` with `## No Ambiguity`, retro-narrated questions never asked, model-inferred Answers.
- `spec.md` — lowercase RFC-2119 keywords, 3-hashtag scenarios silently absorbed as requirement body, missing WHEN/THEN, non-Title-Case headings, MODIFIED/REMOVED header drift, motivation in requirement prose, untestable wording.
- `tasks.md` — missing `[implements:` or `verify:` clauses, slugs that don't resolve to real requirements/decisions, invalid `meta/<kind>`, scenarios without matching test tasks, vague verifies, bundled deliverables.

### Why end-of-template comments

The checklists target a Sonnet/Opus-authored workflow. Models reliably obey explicit grep-and-reclassify instructions embedded in HTML comments; humans tend to treat them as suggestions. Placing the block at the end keeps the template's primary structure intact while giving the drafting model a stop-the-line gate before the artifact is declared done. Because the blocks are HTML comments, OpenSpec's schema validator ignores them entirely.

---

## 2. Block PRs against ClickHouse/mcp-clickhouse

This repo is forked from `ClickHouse/mcp-clickhouse`. `gh pr create` without an explicit `--repo` defaults to the upstream parent, which is never what we want here — a real misfire happened while preparing this PR. The guards cover both surfaces a Claude session might use to open a PR:

- **Bash `gh pr create`** — blocked if `--repo` is missing OR points at `ClickHouse/mcp-clickhouse` (`-R` short form also covered).
- **MCP `*create_pull_request`** — any MCP tool whose name ends in `create_pull_request` (e.g. the official `mcp__github__create_pull_request`, the ECC plugin's `mcp__plugin_ecc_github__create_pull_request`, or any future variant) has its `owner` + `repo` arguments inspected and blocked when they resolve to `ClickHouse/mcp-clickhouse`. No `gh` CLI involvement, so the Bash hook alone wouldn't catch it.

Layers:

- **`.claude/hooks/block-clickhouse-pr.py`** — PreToolUse hook. Dispatches on `tool_name`: Bash handler scans the command string; MCP handler reads `tool_input.owner` / `tool_input.repo`. Exits 2 (hard block) on any forbidden invocation. PreToolUse hooks run in every permission mode (`default`, `auto`, `acceptEdits`, `bypassPermissions`), so this is the authoritative enforcement point.
- **`.claude/settings.json`** — registers the hook against two matchers (`Bash`/`gh pr` and `mcp__.*create_pull_request`), plus backup `permissions.deny` patterns for the Bash `--repo`/`-R` ClickHouse variants. MCP doesn't expose owner-aware deny patterns, so the hook is the only enforcement layer for that surface — which is fine because PreToolUse hooks fire for MCP tool calls the same way they do for Bash.
- **`CLAUDE.md`** — documents the rule for any model or human reading project memory; also notes that PR opens require explicit per-turn user authorization.
- **`.gitignore`** — ignores `.claude/settings.local.json` (Claude Code per-user permission overrides), nothing else.

### How the hook was tested

**Bash path** — exercised the PreToolUse contract (stdin = JSON `{tool_name, tool_input}`, exit 0 allow / exit 2 block) with mock payloads:

| # | `tool_input.command` | Expected | Result |
|---|---|---|---|
| 1 | `gh pr create --repo ClickHouse/mcp-clickhouse --title x` | block, exit 2 | ✅ |
| 2 | `gh pr create --repo hydrolix/mcp-hydrolix --title x` | allow, exit 0 | ✅ |
| 3 | `gh pr create --title x --body y` (no `--repo`) | block, exit 2 | ✅ |
| 4 | `git status` | allow, exit 0 | ✅ |
| 5 | `gh pr create -R ClickHouse/mcp-clickhouse` | block, exit 2 | ✅ |
| 6 | `gh pr list` (no `--repo`) | allow, exit 0 | ✅ |

**MCP path** — exercised with mock payloads:

| # | `tool_name` | `tool_input` | Expected | Result |
|---|---|---|---|---|
| 1 | `mcp__github__create_pull_request` | `owner=ClickHouse, repo=mcp-clickhouse` | block, exit 2 | ✅ |
| 2 | `mcp__github__create_pull_request` | `owner=hydrolix, repo=mcp-hydrolix` | allow, exit 0 | ✅ |
| 3 | `mcp__plugin_ecc_github__create_pull_request` | `owner=clickhouse, repo=mcp-clickhouse` | block, exit 2 | ✅ |
| 4 | `mcp__github__get_issue` | `owner=ClickHouse, repo=mcp-clickhouse` | allow, exit 0 | ✅ (unrelated tool) |
| 5 | `mcp__github__create_pull_request` | `owner=ClIcKhOuSe, repo=mcp-clickhouse` | block, exit 2 | ✅ (case-insensitive) |

---

## Test plan

- [x] Open each `openspec/schemas/interactive-spec-led/templates/*.md` file and confirm the new `<!-- BEFORE FINALIZING -->` block appears as the final content with no edits above it.
- [x] Confirm no existing OpenSpec change is invalidated (the additions are inside HTML comments — no-op for the validator).
- [x] In a fresh Claude session opened in this branch, run `PATH= gh pr create --repo ClickHouse/mcp-clickhouse --title test` and confirm the hook BLOCKED message (not `gh: No such file or directory`).
- [x] In a fresh Claude session with a github MCP server enabled, attempt `mcp__github__create_pull_request` with `owner=ClickHouse, repo=mcp-clickhouse` and confirm the hook BLOCKED message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)