### PR TITLE
[IL][HDX-11442][Spec] OAuth configuration surface

### DIFF
--- a/openspec/changes/oauth-config-and-preflight/.openspec.yaml
+++ b/openspec/changes/oauth-config-and-preflight/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: interactive-spec-led
+created: 2026-05-27

--- a/openspec/changes/oauth-config-and-preflight/design.md
+++ b/openspec/changes/oauth-config-and-preflight/design.md
@@ -1,0 +1,67 @@
+*A single `load_oauth_config()` function owns all env-var parsing; one frozen dataclass owns IdP endpoint knowledge; two distinct exception types surface fatal-startup errors.*
+
+## Context
+
+- `mcp_hydrolix/auth/oauth.py` contains a draft from prior OAuth prototype work; this spec's behavioral contract supersedes the prototype's shape.
+- `webapp.py:create_app()` is the per-worker factory ([HDX-10675](https://hydrolix.atlassian.net/browse/HDX-10675)); runs before uvicorn's event loop starts.
+- `HYDROLIX_URL` is provided by [HDX-11441](https://hydrolix.atlassian.net/browse/HDX-11441); consumed here as a plain string; no URL-parsing logic added.
+- The cluster-URL-to-IdP convention is [HDX-11431](https://hydrolix.atlassian.net/browse/HDX-11431)'s deliverable; the derivation function is a stub until it lands.
+- The non-conflation invariant (issuer ≠ cluster URL) is enforced at request time by `oauth-jwt-verifier`. See `non-conflation-is-a-verifier-invariant` below.
+
+## OAuthConfig Fields Owned By This Change
+
+`OAuthConfig` is defined here with: `issuer`, `audience`, `required_scopes`, `jwks_uri`, `allow_insecure_jwks`. The `resource_url` field is added by `oauth-resource-metadata` in a later change.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Single entry point for all `HYDROLIX_OAUTH_*` validation.
+- Single encapsulation point for IdP endpoint knowledge.
+- Visually distinct fatal-startup exception types.
+- Fail-open network failures at startup.
+
+**Fail-open contract**: `try_activate_oauth()` catches OIDC discovery, JWKS preflight, and HTTP/JSON errors internally; emits the single `WARNING "OAuth configured but not activated <ExcClass>"` log line itself; and returns `None`. Callers (notably `oauth-auth-chain-and-activation`'s wiring function) check the return value rather than catching exceptions.
+
+**Non-Goals:**
+- `canonical_idp_endpoints` body ([HDX-11431](https://hydrolix.atlassian.net/browse/HDX-11431)).
+- Request-time bearer verification (`oauth-jwt-verifier`, `oauth-auth-chain-and-activation`).
+- RFC 9728 resource-metadata endpoint (`oauth-resource-metadata`).
+- Log-redaction (`oauth-log-redaction`).
+
+## Decisions
+
+### Decision: single-idp-coupling-point
+
+- **Choice:** All IdP endpoint knowledge lives in `canonical_idp_endpoints()` in `mcp_hydrolix/auth/idp_endpoints.py`, returning a frozen dataclass with fields `issuer`, `discovery_url`, `jwks_uri`, `address`.
+- **Why:** A single function forces all IdP-shaped changes through one signature and one test suite; `grep canonical_idp_endpoints` is a complete audit of IdP coupling in an otherwise IdP-agnostic codebase.
+- **Alternatives:** Separate per-field getters — rejected (IdP knowledge scatters); placing it in [HDX-11441](https://hydrolix.atlassian.net/browse/HDX-11441)'s module — rejected (wrong dependency direction; that module should not know about OAuth).
+- **Binding:** No code outside `mcp_hydrolix/auth/idp_endpoints.py` SHALL encode how IdP endpoint URLs relate to `HYDROLIX_URL`. `load_oauth_config()` SHALL call `canonical_idp_endpoints` when `HYDROLIX_OAUTH_ISSUER` is unset and `HYDROLIX_URL` is set; it SHALL NOT inline URL-construction logic.
+
+### Decision: two-distinct-fatal-startup-exceptions
+
+- **Choice:** `OAuthConfigError` for operator-misconfigured vars; `NotImplementedError` from `canonical_idp_endpoints` propagates unwrapped for the pre-[HDX-11431](https://hydrolix.atlassian.net/browse/HDX-11431) stub.
+- **Why:** The two cases demand different operator actions — "fix your env vars" vs. "wait for [HDX-11431](https://hydrolix.atlassian.net/browse/HDX-11431)". Wrapping both under one exception type sends operators on a misconfiguration hunt when the real problem is a missing implementation.
+- **Alternatives:** Single `OAuthStartupError` — rejected (conflates operationally distinct causes); catch and log + disable — rejected (silences a real capability gap).
+- **Binding:** `load_oauth_config()` SHALL raise `OAuthConfigError` for all partial-configuration cases and SHALL NOT catch `NotImplementedError` from `canonical_idp_endpoints`.
+
+### Decision: non-conflation-is-a-verifier-invariant
+
+- **Choice:** No startup check compares `HYDROLIX_OAUTH_ISSUER` against `HYDROLIX_URL`; the non-conflation invariant is enforced at request time by `oauth-jwt-verifier`.
+- **Why:** A startup check would couple this change to [HDX-11441](https://hydrolix.atlassian.net/browse/HDX-11441)'s env-var surface (`HYDROLIX_URL` may be unset) with no security benefit — the verifier rejects a conflated issuer at request time regardless.
+- **Alternatives:** Startup assertion comparing the two vars — rejected; [HDX-11441](https://hydrolix.atlassian.net/browse/HDX-11441) may not have landed and the coupling is not worth the marginal value.
+- **Binding:** `load_oauth_config()` SHALL NOT compare `HYDROLIX_OAUTH_ISSUER` against `HYDROLIX_URL`. The conflation test belongs in `oauth-jwt-verifier`'s suite, not here.
+
+## Risks / Trade-offs
+
+- OIDC discovery adds O(hundreds of ms) per worker startup; bounded by a discovery timeout constant; document in `docs/oauth.md`.
+- Workers diverge if some preflights fail (some serve with OAuth, others SA-only); operators see WARNING lines per worker; a follow-up can add a Prometheus counter.
+- `asyncio.run()` in the factory is fragile if moved under a running loop; a test asserting loud `RuntimeError` in that case guards against future refactors.
+- Stub `NotImplementedError` may surprise operators combining `HYDROLIX_OAUTH_AUDIENCE` with `HYDROLIX_URL`; the exception message MUST contain `HDX-11431` and `docs/oauth.md` MUST document the interim requirement for explicit `HYDROLIX_OAUTH_ISSUER`.
+
+## Migration Plan
+
+Unset all `HYDROLIX_OAUTH_*` env vars to restore pre-OAuth behavior; no data or schema changes.
+
+## Open Questions
+
+- Traefik routing: confirm staging cluster rules do not rewrite the `/mcp` prefix in a way that hides `/.well-known/oauth-protected-resource` before `oauth-resource-metadata` ships.

--- a/openspec/changes/oauth-config-and-preflight/explore.md
+++ b/openspec/changes/oauth-config-and-preflight/explore.md
@@ -1,0 +1,10 @@
+*This change was formed before openspec introduced `explore.md` as a required artifact. No genuine pre-spec audit trail exists; the substantive design choices are recorded in `design.md`. The Q&A below disambiguates one point that an independent reviewer might otherwise misread.*
+
+## Decisions
+
+### Decision: primitive-owns-the-warning
+
+- **Question**: Why does the startup preflight primitive itself emit the WARNING and return `None` on failure, rather than raising and letting the calling activation function decide what to log?
+- **Answer**: The fail-open contract — "the worker SHALL emit a single WARNING log line and continue serving with the credential chain only" — is the body of the **Startup Preflight Is Fail-Open** requirement, owned by this change. Co-locating the emitter with the requirement keeps the contract complete in one file. The alternative (caller catches preflight exceptions and logs the WARNING itself) was considered and rejected because it splits ownership of a single WARNING across two changes; an implementer reading either spec alone would be unable to tell what the other emits.
+- **Rationale**: The WARNING is a behavioral contract, not an implementation detail. Whoever owns the requirement owns the emission.
+- **Affects**: `try_activate_oauth()` signature in `mcp_hydrolix/auth/oauth.py` (returns `OAuthHydrolixAuthProvider | None` instead of raising); design.md "Fail-open contract" line in the Goals section; tasks.md task 3.1.

--- a/openspec/changes/oauth-config-and-preflight/proposal.md
+++ b/openspec/changes/oauth-config-and-preflight/proposal.md
@@ -1,0 +1,46 @@
+*Adds configuration loading, activation gating, canonical IdP endpoint derivation, JWKS URI override, and fail-open startup preflight for OAuth bearer authentication.*
+
+## Why
+
+mcp-hydrolix needs a well-defined configuration layer before any OAuth-adjacent feature can ship: the rules governing which env vars activate OAuth, how the issuer is resolved, how insecure JWKS URIs are guarded, and what happens when OIDC discovery fails at startup must all be specified and tested independently of the verifier, the resource-metadata endpoint, and the auth-chain wiring. This change establishes that foundation.
+
+## Family Context / Forward References
+
+One of 5 changes decomposing OAuth bearer authentication for [HDX-11442](https://hydrolix.atlassian.net/browse/HDX-11442). All five target the shared capability `oauth-authentication`. Dependency order:
+
+- `oauth-config-and-preflight` (this change) — root of the dep graph; no upstream deps.
+- `oauth-resource-metadata` — depends on this change (consumes `OAuthConfig.issuer` / `OAuthConfig.resource_url`).
+- `oauth-jwt-verifier` — depends on this change (consumes `OAuthConfig.issuer`, `audience`, `required_scopes`).
+- `oauth-auth-chain-and-activation` — depends on `oauth-jwt-verifier` (composes its provider with the SA chain).
+- `oauth-log-redaction` — orthogonal; can land anywhere in the sequence.
+
+## What Changes
+
+- OAuth bearer authentication activates only when `HYDROLIX_OAUTH_AUDIENCE` is set and an issuer is resolvable; without those vars the server is byte-identical to a build without OAuth code.
+- Partial or conflicting `HYDROLIX_OAUTH_*` configuration causes a fatal startup error surfaced as `OAuthConfigError`.
+- All cluster-URL-to-IdP endpoint knowledge is encapsulated in a single module; no other code may encode that mapping.
+- Plain-HTTP JWKS URIs are rejected at startup unless an explicit insecure opt-in flag is set.
+- OIDC discovery and JWKS preflight failures at startup are fail-open: the worker logs a warning and continues without OAuth active.
+
+## Capabilities
+
+### New
+
+- `oauth-authentication` — the OAuth bearer authentication feature for mcp-hydrolix HTTP/SSE transports. This change establishes the capability and contributes:
+  - Env-var activation gate.
+  - Canonical IdP endpoint derivation.
+  - JWKS URI override and insecure transport flag.
+  - Fail-open OIDC discovery + JWKS startup preflight.
+
+  Downstream changes in the family (`oauth-jwt-verifier`, `oauth-auth-chain-and-activation`, `oauth-resource-metadata`, `oauth-log-redaction`) extend the capability via `### Modified` deltas.
+
+### Modified
+
+*none*
+
+## Impact
+
+- **mcp_hydrolix/auth/oauth.py**: config loading, error types, and `try_activate_oauth()` preflight primitive
+- **mcp_hydrolix/auth/idp_endpoints.py** (new): IdP endpoint encapsulation module
+- **tests/auth/**: new test modules
+- No new production dependencies

--- a/openspec/changes/oauth-config-and-preflight/specs/oauth-authentication/spec.md
+++ b/openspec/changes/oauth-config-and-preflight/specs/oauth-authentication/spec.md
@@ -1,0 +1,120 @@
+*Covers OAuth activation gating, issuer precedence, canonical IdP endpoint derivation, JWKS URI override, and fail-open startup preflight.*
+
+## ADDED Requirements
+
+### Requirement: Activation Gated On Env Vars
+
+The server SHALL activate OAuth if and only if `HYDROLIX_OAUTH_AUDIENCE` is set AND a usable issuer is resolvable via this precedence:
+
+1. `HYDROLIX_OAUTH_ISSUER` if non-empty (explicit override).
+2. `canonical_idp_endpoints(HYDROLIX_URL).issuer` if `HYDROLIX_URL` is non-empty.
+3. Otherwise unresolved — OAuth not activated.
+
+Without activation and without partial config, the server is byte-identical to a build without OAuth code. `HYDROLIX_URL` alone is not an OAuth signal.
+
+**Partial configuration** — server SHALL raise `OAuthConfigError` at startup for:
+- `HYDROLIX_OAUTH_AUDIENCE` set but neither `HYDROLIX_OAUTH_ISSUER` nor `HYDROLIX_URL` set.
+- `HYDROLIX_OAUTH_ISSUER` set but `HYDROLIX_OAUTH_AUDIENCE` unset.
+- Any of `HYDROLIX_OAUTH_JWKS_URI`, `HYDROLIX_OAUTH_ALLOW_INSECURE_JWKS`, `HYDROLIX_OAUTH_REQUIRED_SCOPES`, `HYDROLIX_OAUTH_RESOURCE_URL` set but `HYDROLIX_OAUTH_AUDIENCE` unset.
+
+When `HYDROLIX_OAUTH_AUDIENCE` + `HYDROLIX_URL` are set and `canonical_idp_endpoints` raises `NotImplementedError`, that is NOT partial config — `NotImplementedError` propagates unwrapped.
+
+#### Scenario: No OAuth Vars Set
+
+- **WHEN** no `HYDROLIX_OAUTH_*` vars and no `HYDROLIX_URL` are set
+- **THEN** the server SHALL NOT emit any log line containing `OAuth`
+- **AND** `/.well-known/oauth-protected-resource` SHALL return 404
+- **AND** MCP tool endpoints with no bearer token SHALL behave as on a build with no OAuth code
+
+#### Scenario: Audience Set But No Issuer Resolvable
+
+- **WHEN** `HYDROLIX_OAUTH_AUDIENCE` is set
+- **AND** neither `HYDROLIX_OAUTH_ISSUER` nor `HYDROLIX_URL` is set
+- **THEN** the worker SHALL raise `OAuthConfigError` during factory initialization
+- **AND** SHALL NOT serve any request
+
+#### Scenario: Issuer Derivation Attempted Before HDX-11431
+
+- **WHEN** `HYDROLIX_OAUTH_AUDIENCE` and `HYDROLIX_URL` are both set, `HYDROLIX_OAUTH_ISSUER` unset
+- **AND** the derivation stub raises `NotImplementedError`
+- **THEN** the worker SHALL terminate at factory initialization
+- **AND** the propagated exception SHALL be `NotImplementedError`, not `OAuthConfigError`
+- **AND** the error message SHALL contain `HDX-11431`
+
+#### Scenario: Issuer Derived From Cluster URL Post-HDX-11431
+
+- **WHEN** `canonical_idp_endpoints` is replaced with a test implementation returning `CanonicalIdPEndpoints(issuer="https://idp.example.com/realms/hydrolix", discovery_url="https://idp.example.com/realms/hydrolix/.well-known/openid-configuration", jwks_uri="https://idp.example.com/realms/hydrolix/protocol/openid-connect/certs", address="idp.example.com")` for the given `hydrolix_url`
+- **AND** `HYDROLIX_OAUTH_AUDIENCE` and `HYDROLIX_URL` are set, `HYDROLIX_OAUTH_ISSUER` unset
+- **THEN** the server SHALL resolve the issuer via `canonical_idp_endpoints(HYDROLIX_URL).issuer`
+- **AND** OAuth SHALL activate using the derived issuer
+
+#### Scenario: Explicit Issuer Overrides Derivation
+
+- **WHEN** `HYDROLIX_OAUTH_ISSUER`, `HYDROLIX_OAUTH_AUDIENCE`, and `HYDROLIX_URL` are all set
+- **AND** the explicit issuer differs from the value that would be derived from `HYDROLIX_URL`
+- **THEN** the server SHALL use `HYDROLIX_OAUTH_ISSUER`
+- **AND** SHALL NOT raise a startup error for the mismatch
+
+#### Scenario: Issuer Set But Audience Unset
+
+- **WHEN** `HYDROLIX_OAUTH_ISSUER` is set but `HYDROLIX_OAUTH_AUDIENCE` is unset
+- **THEN** the worker SHALL raise `OAuthConfigError` during factory initialization
+
+#### Scenario: Hydrolix URL Set Without OAuth Vars
+
+- **WHEN** `HYDROLIX_URL` is set and no `HYDROLIX_OAUTH_*` vars are set
+- **THEN** OAuth SHALL NOT activate
+- **AND** the server SHALL be byte-identical to a build without OAuth code
+
+#### Scenario: Optional OAuth Var Set Without Audience
+
+- **WHEN** any of `HYDROLIX_OAUTH_JWKS_URI`, `HYDROLIX_OAUTH_REQUIRED_SCOPES`, `HYDROLIX_OAUTH_ALLOW_INSECURE_JWKS`, or `HYDROLIX_OAUTH_RESOURCE_URL` is set and `HYDROLIX_OAUTH_AUDIENCE` is unset
+- **THEN** the worker SHALL raise `OAuthConfigError` during factory initialization
+
+### Requirement: Canonical IdP Endpoint Derivation Is A Single Contained Function
+
+`canonical_idp_endpoints(hydrolix_url: str) -> CanonicalIdPEndpoints` in `mcp_hydrolix.auth.idp_endpoints` is the sole location for cluster-URL-to-IdP knowledge. Until [HDX-11431](https://hydrolix.atlassian.net/browse/HDX-11431) lands, it SHALL raise `NotImplementedError` with a message containing `HDX-11431`. When implemented, the returned record SHALL be frozen with fields `issuer`, `discovery_url`, `jwks_uri`, `address`, and SHALL never return `issuer` equal to the input `hydrolix_url`.
+
+#### Scenario: Stub Raises Not Implemented Error Until HDX-11431
+
+- **WHEN** `canonical_idp_endpoints` is called with any `hydrolix_url`
+- **THEN** the function SHALL raise `NotImplementedError` with message containing `HDX-11431`
+
+#### Scenario: Eventual Return Shape Is Immutable And Complete
+
+- **WHEN** `canonical_idp_endpoints` is replaced with a test implementation returning a `CanonicalIdPEndpoints` record
+- **AND** called with any non-empty `hydrolix_url`
+- **THEN** the record SHALL be frozen, expose `issuer`, `discovery_url`, `jwks_uri`, `address` as strings, and equal records returned for equal inputs
+
+#### Scenario: Eventual Derived Issuer Is Never Equal To Input Cluster URL
+
+- **WHEN** `canonical_idp_endpoints` is replaced with a test implementation and called with any non-empty `hydrolix_url`
+- **THEN** the returned `issuer` SHALL NOT be string-equal to `hydrolix_url`
+
+### Requirement: JWKS URI Override And Insecure Transport Flag
+
+`load_oauth_config()` SHALL accept `HYDROLIX_OAUTH_JWKS_URI` for in-cluster deployments. When that URI uses `http://` and `HYDROLIX_OAUTH_ALLOW_INSECURE_JWKS` is not `"true"`, `load_oauth_config()` SHALL raise `OAuthConfigError` before any network call. When `HYDROLIX_OAUTH_ALLOW_INSECURE_JWKS=true` is also set, the `http://` URI is accepted.
+
+#### Scenario: Plain HTTP JWKS Rejected By Default
+
+- **WHEN** `HYDROLIX_OAUTH_AUDIENCE` and `HYDROLIX_OAUTH_ISSUER` are set
+- **AND** `HYDROLIX_OAUTH_JWKS_URI="http://idp.internal/realms/x/protocol/openid-connect/certs"`
+- **AND** `HYDROLIX_OAUTH_ALLOW_INSECURE_JWKS` is unset
+- **THEN** `load_oauth_config()` SHALL raise `OAuthConfigError`
+
+#### Scenario: Plain HTTP JWKS Allowed When Explicitly Opted In
+
+- **WHEN** `HYDROLIX_OAUTH_AUDIENCE` and `HYDROLIX_OAUTH_ISSUER` are set
+- **AND** `HYDROLIX_OAUTH_JWKS_URI="http://idp.internal/.../certs"` and `HYDROLIX_OAUTH_ALLOW_INSECURE_JWKS="true"` are set
+- **THEN** `load_oauth_config()` SHALL accept the configuration
+
+### Requirement: Startup Preflight Is Fail-Open
+
+On OIDC discovery or JWKS preflight failure (network error, non-2xx, malformed JSON, missing `jwks_uri`), the worker SHALL emit one WARNING containing `OAuth configured but not activated` and continue serving credential-chain only.
+
+#### Scenario: Discovery Network Failure At Startup
+
+- **WHEN** the OIDC discovery endpoint is unreachable at worker startup
+- **THEN** the worker SHALL log exactly one WARNING containing `OAuth configured but not activated` and the network failure class name
+- **AND** the worker SHALL continue serving with `mcp.auth` set to the credential chain
+- **AND** SHALL NOT raise an exception at startup

--- a/openspec/changes/oauth-config-and-preflight/tasks.md
+++ b/openspec/changes/oauth-config-and-preflight/tasks.md
@@ -1,0 +1,43 @@
+*5 phases, 22 tasks; new IdP module, config loader, startup preflight primitive, 14 scenario tests, docs.*
+
+## 1. IdP Endpoint Module
+
+- [ ] 1.1 Create `mcp_hydrolix/auth/idp_endpoints.py`: `CanonicalIdPEndpoints` as `@dataclass(frozen=True)` with fields `issuer: str`, `discovery_url: str`, `jwks_uri: str`, `address: str` [implements: design/single-idp-coupling-point, spec/canonical-idp-endpoint-derivation-is-a-single-contained-function] — verify: `ruff check mcp_hydrolix/auth/idp_endpoints.py` clean; module imports without error
+- [ ] 1.2 Add `canonical_idp_endpoints(hydrolix_url: str) -> CanonicalIdPEndpoints` stub raising `NotImplementedError` with message containing `HDX-11431` [implements: design/single-idp-coupling-point] — verify: `pytest -q tests/auth/test_oauth_config_and_preflight.py::test_stub_raises_not_implemented_error_until_hdx_11431` green
+
+## 2. Config Loader
+
+- [ ] 2.1 Add `OAuthConfigError` to `mcp_hydrolix/auth/oauth.py` [implements: design/two-distinct-fatal-startup-exceptions] — verify: `from mcp_hydrolix.auth.oauth import OAuthConfigError` succeeds
+- [ ] 2.2 Add `OAuthConfig` frozen dataclass in `mcp_hydrolix/auth/oauth.py` with fields: `issuer: str`, `audience: list[str]`, `required_scopes: list[str]`, `jwks_uri: str | None`, `allow_insecure_jwks: bool` (`resource_url` is added by `oauth-resource-metadata`) [implements: spec/activation-gated-on-env-vars, spec/jwks-uri-override-and-insecure-transport-flag] — verify: `ruff check mcp_hydrolix/auth/oauth.py` clean
+- [ ] 2.3a Implement issuer precedence in `load_oauth_config()`: explicit `HYDROLIX_OAUTH_ISSUER` > `canonical_idp_endpoints(HYDROLIX_URL).issuer` > unset [implements: design/single-idp-coupling-point] — verify: `pytest -q tests/auth/test_oauth_config_and_preflight.py::test_explicit_issuer_overrides_derivation` green
+- [ ] 2.3b Raise `OAuthConfigError` for all partial-config cases [implements: design/two-distinct-fatal-startup-exceptions] — verify: `pytest -q tests/auth/test_oauth_config_and_preflight.py::test_partial_config_raises` green
+- [ ] 2.3c Let `NotImplementedError` from `canonical_idp_endpoints` propagate unwrapped [implements: design/two-distinct-fatal-startup-exceptions] — verify: `pytest -q tests/auth/test_oauth_config_and_preflight.py::test_not_implemented_error_propagates_unwrapped` green
+- [ ] 2.4 Insecure-JWKS guard: `http://` `HYDROLIX_OAUTH_JWKS_URI` without `HYDROLIX_OAUTH_ALLOW_INSECURE_JWKS=true` raises `OAuthConfigError` before any network call [implements: spec/jwks-uri-override-and-insecure-transport-flag] — verify: `pytest -q tests/auth/test_oauth_config_and_preflight.py::test_plain_http_jwks_rejected_by_default` green
+
+## 3. Startup Preflight Primitive
+
+- [ ] 3.1 Implement `try_activate_oauth(cfg: OAuthConfig) -> OAuthHydrolixAuthProvider | None` in `mcp_hydrolix/auth/oauth.py`: perform async OIDC discovery (GET `cfg.issuer + "/.well-known/openid-configuration"`), retrieve JWKS URI (use `cfg.jwks_uri` if set, else field from discovery response), verify JWKS endpoint is reachable; **catch** any network error, non-2xx HTTP response, malformed JSON, or missing `jwks_uri` field, log one WARNING `OAuth configured but not activated <ExcClass>`, and return `None`; on success return a configured `OAuthHydrolixAuthProvider`. The primitive owns the WARNING emission per the fail-open contract in design.md; callers check the return value rather than catching exceptions [implements: oauth-authentication/startup-preflight-is-fail-open] — verify: `pytest -q tests/auth/test_try_activate_oauth.py` green
+- [ ] 3.2 No code outside `mcp_hydrolix/auth/idp_endpoints.py` encodes IdP URL structure [implements: design/single-idp-coupling-point] — verify: `grep -rl "HYDROLIX_URL" mcp_hydrolix/auth/ --include="*.py" | sort` outputs exactly `mcp_hydrolix/auth/idp_endpoints.py` and `mcp_hydrolix/auth/oauth.py`, AND `grep -n "HYDROLIX_URL" mcp_hydrolix/auth/oauth.py` shows only `os.environ`/`os.getenv` calls (no string concatenation or f-strings)
+
+## 4. Tests
+
+All tests in `tests/auth/test_oauth_config_and_preflight.py`.
+
+- [ ] 4.1 `test_no_oauth_vars_set` [implements: oauth-authentication/activation-gated-on-env-vars] — verify green
+- [ ] 4.2 `test_audience_set_but_no_issuer_resolvable` [implements: oauth-authentication/activation-gated-on-env-vars] — verify green
+- [ ] 4.3 `test_issuer_derivation_attempted_before_hdx_11431` [implements: oauth-authentication/activation-gated-on-env-vars] — verify green
+- [ ] 4.4 `test_issuer_derived_from_cluster_url_post_hdx_11431` (monkeypatch `canonical_idp_endpoints`) [implements: oauth-authentication/activation-gated-on-env-vars] — verify green
+- [ ] 4.5 `test_explicit_issuer_overrides_derivation` [implements: oauth-authentication/activation-gated-on-env-vars] — verify green
+- [ ] 4.6 `test_issuer_set_but_audience_unset` [implements: oauth-authentication/activation-gated-on-env-vars] — verify green
+- [ ] 4.7 `test_hydrolix_url_set_without_oauth_vars` [implements: oauth-authentication/activation-gated-on-env-vars] — verify green
+- [ ] 4.8 `test_optional_oauth_var_set_without_audience` [implements: oauth-authentication/activation-gated-on-env-vars] — verify green
+- [ ] 4.9 `test_stub_raises_not_implemented_error_until_hdx_11431` [implements: oauth-authentication/canonical-idp-endpoint-derivation-is-a-single-contained-function] — verify green
+- [ ] 4.10 `test_eventual_return_shape_is_immutable_and_complete` (monkeypatch stub) [implements: oauth-authentication/canonical-idp-endpoint-derivation-is-a-single-contained-function] — verify green
+- [ ] 4.11 `test_eventual_derived_issuer_is_never_equal_to_input_cluster_url` (monkeypatch stub) [implements: oauth-authentication/canonical-idp-endpoint-derivation-is-a-single-contained-function] — verify green
+- [ ] 4.12 `test_plain_http_jwks_rejected_by_default` [implements: oauth-authentication/jwks-uri-override-and-insecure-transport-flag] — verify green
+- [ ] 4.13 `test_plain_http_jwks_allowed_when_explicitly_opted_in` [implements: oauth-authentication/jwks-uri-override-and-insecure-transport-flag] — verify green
+- [ ] 4.14 `test_discovery_network_failure_at_startup` [implements: oauth-authentication/startup-preflight-is-fail-open] — verify green
+
+## 5. Documentation
+
+- [ ] 5.1 Update/create `docs/oauth.md`: all `HYDROLIX_OAUTH_*` vars, issuer precedence chain, interim requirement for explicit `HYDROLIX_OAUTH_ISSUER` until [HDX-11431](https://hydrolix.atlassian.net/browse/HDX-11431), OIDC discovery latency, insecure-JWKS opt-in [implements: meta/docs] — verify: `docs/oauth.md` contains substrings `HYDROLIX_OAUTH_ISSUER` and `HDX-11431`


### PR DESCRIPTION
What does this PR do?
-----------------------

Root of a 5-change OpenSpec decomposition of OAuth bearer authentication for [HDX-11442](https://hydrolix.atlassian.net/browse/HDX-11442). Establishes the `oauth-authentication` capability and contributes:

- Env-var activation gate (`HYDROLIX_OAUTH_AUDIENCE` + resolvable issuer); partial config is a fatal `OAuthConfigError`.
- Canonical IdP endpoint derivation in a single function; stub raises `NotImplementedError` until [HDX-11431](https://hydrolix.atlassian.net/browse/HDX-11431).
- JWKS URI override + insecure-scheme guard.
- Startup preflight primitive `try_activate_oauth(cfg)` with a fail-open contract: catches preflight errors, emits a single WARNING, returns `None`.

Spec-only PR — nocode changes. Downstream changes (`oauth-jwt-verifier`, `oauth-auth-chain-and-activation`, `oauth-resource-metadata`, `oauth-log-redaction`) will extend this capability via `### Modified` deltas and are tracked as separate PRs.

Does this PR meet the acceptance criteria?
--------------------------------------------

* [x] Documentation created/updated — the spec under `openspec/changes/oauth-config-and-preflight/` is itself the documentation surface.
* [ ] Tests added for this feature/bug — not applicable; this is the contract spec, pre-implementation. Tests land during `/opsx:apply`.
* [x] Does this change request have any security impacts? — yes, OAuth feature; security-relevant decisions are documented in `design.md` (fail-open contract, JWKS-insecure guard, two distinct fatal-startup exceptions, single IdP coupling point) and reviewable in isolation here.

Release Notes
---------------------------------------------------

* Major changes:
    * none (spec-only)
* Minor changes:
    * Adds OpenSpec change `oauth-config-and-preflight` establishing the `oauth-authentication` capability with 4 requirements
* Bugfixes:
    * none
* Issues Closed:
    * [HDX-11442](https://hydrolix.atlassian.net/browse/HDX-11442) — partially (root of decomposition)
* Security impacts identified:
    * Establishes the OAuth bearer-auth security contract: activation gating, partial-config fatal errors, insecure-JWKS guard, and fail-open startup. Specifies behavior; production code arrives in subsequent PRs.

Testing
--------------------------------------------

* `openspec validate oauth-config-and-preflight` — passes.
* No code under test in this PR. Verification of the spec's syntactic and structural correctness is the openspec validator.

[HDX-11442]: https://hydrolix.atlassian.net/browse/HDX-11442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HDX-11431]: https://hydrolix.atlassian.net/browse/HDX-11431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[HDX-11442]: https://hydrolix.atlassian.net/browse/HDX-11442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ