### PR TITLE
[Spec] OAuth resource metadata endpoint

### DIFF
--- a/openspec/changes/oauth-config-and-preflight/specs/oauth-authentication/spec.md
+++ b/openspec/changes/oauth-config-and-preflight/specs/oauth-authentication/spec.md
@@ -15,7 +15,7 @@ Without activation and without partial config, the server is byte-identical to a
 **Partial configuration** — server SHALL raise `OAuthConfigError` at startup for:
 - `HYDROLIX_OAUTH_AUDIENCE` set but neither `HYDROLIX_OAUTH_ISSUER` nor `HYDROLIX_URL` set.
 - `HYDROLIX_OAUTH_ISSUER` set but `HYDROLIX_OAUTH_AUDIENCE` unset.
-- Any of `HYDROLIX_OAUTH_JWKS_URI`, `HYDROLIX_OAUTH_ALLOW_INSECURE_JWKS`, `HYDROLIX_OAUTH_REQUIRED_SCOPES`, `HYDROLIX_OAUTH_RESOURCE_URL` set but `HYDROLIX_OAUTH_AUDIENCE` unset.
+- Any of `HYDROLIX_OAUTH_JWKS_URI`, `HYDROLIX_OAUTH_ALLOW_INSECURE_JWKS`, `HYDROLIX_OAUTH_REQUIRED_SCOPES` set but `HYDROLIX_OAUTH_AUDIENCE` unset.
 
 When `HYDROLIX_OAUTH_AUDIENCE` + `HYDROLIX_URL` are set and `canonical_idp_endpoints` raises `NotImplementedError`, that is NOT partial config — `NotImplementedError` propagates unwrapped.
 
@@ -68,7 +68,7 @@ When `HYDROLIX_OAUTH_AUDIENCE` + `HYDROLIX_URL` are set and `canonical_idp_endpo
 
 #### Scenario: Optional OAuth Var Set Without Audience
 
-- **WHEN** any of `HYDROLIX_OAUTH_JWKS_URI`, `HYDROLIX_OAUTH_REQUIRED_SCOPES`, `HYDROLIX_OAUTH_ALLOW_INSECURE_JWKS`, or `HYDROLIX_OAUTH_RESOURCE_URL` is set and `HYDROLIX_OAUTH_AUDIENCE` is unset
+- **WHEN** any of `HYDROLIX_OAUTH_JWKS_URI`, `HYDROLIX_OAUTH_REQUIRED_SCOPES`, or `HYDROLIX_OAUTH_ALLOW_INSECURE_JWKS` is set and `HYDROLIX_OAUTH_AUDIENCE` is unset
 - **THEN** the worker SHALL raise `OAuthConfigError` during factory initialization
 
 ### Requirement: Canonical IdP Endpoint Derivation Is A Single Contained Function

--- a/openspec/changes/oauth-resource-metadata/.openspec.yaml
+++ b/openspec/changes/oauth-resource-metadata/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: interactive-spec-led
+created: 2026-05-27

--- a/openspec/changes/oauth-resource-metadata/design.md
+++ b/openspec/changes/oauth-resource-metadata/design.md
@@ -1,0 +1,105 @@
+*Register an unauthenticated RFC 9728 metadata route at the path-scoped location `/.well-known/oauth-protected-resource/mcp` and add a resource-URL precedence resolver to `OAuthConfig`.*
+
+## Context
+
+- OAuth activation, `OAuthConfig` shape, and the partial-config error path are defined by `oauth-config-and-preflight`. This change adds one field to that config and registers one new route.
+- New routes are registered on the ASGI app returned by `create_app()` in `webapp.py` (FastAPI/Starlette under FastMCP).
+- When `oauth-jwt-verifier` or `oauth-auth-chain-and-activation` has landed, requests rejected at the auth layer return HTTP 401 with a `WWW-Authenticate: Bearer realm=…` header. This change appends a `resource_metadata=<url>` parameter to that header when present. The RFC 9728 metadata endpoint itself functions independently of any 401-emitting path — it can be exercised standalone.
+- RFC 9728 §3 forbids protecting the metadata endpoint with the credentials it describes.
+- `HYDROLIX_URL` is owned by `hydrolix-url-config-collapse`; this change consumes it.
+
+## Goals / Non-Goals
+
+**Goals:**
+- One new route, registered only when OAuth is active.
+- `OAuthConfig.resource_url` resolved at `create_app()` time.
+- No operator override env var for `resource_url` — single source of truth is `HYDROLIX_URL` (with bind-URL fallback). See "no-resource-url-override" decision.
+- No new external dependencies.
+
+**Non-Goals:**
+- RFC 9728 metadata when OAuth is inactive (returns 404).
+- Authorization server metadata endpoint (RFC 8414) — belongs to the IdP.
+- Caching or signing the document.
+
+## Decisions
+
+### Decision: path-scoped-well-known-per-rfc-9728
+
+**Choice:** Serve the metadata endpoint at the RFC 9728 §3 canonical path-scoped location — `/.well-known/oauth-protected-resource` + the path component of `OAuthConfig.resource_url` (i.e. `/.well-known/oauth-protected-resource/mcp` for the default chain) — registered as a plain Starlette/FastAPI route on the ASGI app inside `create_app()` before any auth middleware is applied, guarded by the same `oauth_active` flag used for the JWT verifier middleware.
+
+**Why:** Three forces pick the path; one operational constraint picks the registration site.
+
+1. **RFC 9728 §3** inserts the well-known suffix between authority and resource path. For a path-scoped resource like `https://cluster.example.com/mcp`, the canonical metadata URL is `https://cluster.example.com/.well-known/oauth-protected-resource/mcp`. Serving at the bare origin root would only be RFC-canonical if the resource identifier had no path component.
+2. **Traefik shares ingress across services** in the Hydrolix cluster. A rule allowing unauthenticated `GET /.well-known/oauth-protected-resource` at the origin root would apply to every backend behind the same router, not just MCP. The path-scoped form lets the Traefik rule target exactly the suffix this service owns.
+3. **Clients that have already seen a 401** find the metadata via the `WWW-Authenticate: resource_metadata=<url>` parameter regardless of path; the location only matters to clients doing pure RFC 9728 discovery without a prior 401, and for them the canonical path is the correct one.
+4. **Registration mechanics:** the route must be unauthenticated, so it cannot go through the auth middleware stack. Registering it directly on the ASGI app object before mounting FastMCP tools (and before any auth middleware) is the simplest placement that bypasses auth while remaining inside the same ASGI process. The path is computed at `create_app()` time from `OAuthConfig.resource_url.path`, not registered as a wildcard — exactly one absolute path is served.
+
+**Alternatives:**
+- Origin root `/.well-known/oauth-protected-resource`: violates RFC 9728 §3 for path-scoped resources; Traefik allowlist would over-share.
+- Under MCP mount `/mcp/.well-known/oauth-protected-resource`: operationally appealing (same Traefik router as MCP) but non-standard — strict RFC 9728 clients without a prior 401 would 404.
+- Mount as a sub-application at the ASGI root: more complexity, no benefit.
+- Add via FastMCP `custom_routes`: FastMCP's custom route surface is not yet stable and may apply auth middleware.
+
+**Binding:** The metadata endpoint SHALL be at `/.well-known/oauth-protected-resource{resource_url.path}`. The handler MUST be registered before any auth middleware is applied to the app so unauthenticated GET requests reach it directly. The registered path MUST be derived from `OAuthConfig.resource_url.path`, not hard-coded — this keeps the implementation honest about the path-scoped contract and ready for a future operator-override env var without code surgery. The worker SHALL NOT register a handler for the origin root `/.well-known/oauth-protected-resource` (no suffix); tests SHALL assert the worker itself returns 404 at that path. The worker does not constrain cluster-level behavior at the root path — that location is left unclaimed so a future broader-scoped service in the cluster may claim it via ingress routing.
+
+### Decision: resource-url-bind-url-fallback
+
+**Choice:** When `HYDROLIX_URL` is absent, `OAuthConfig.resource_url` is populated from the server's bind address (host + port from the uvicorn/Hypercorn config) **with `/mcp` appended** at `create_app()` time, not from a fallback string constant.
+
+**Why:** A hardcoded fallback like `http://localhost:8000` would be correct only for development; production workers may bind to non-default ports or addresses. Reading the actual bind config is the only way to produce a correct default. The `/mcp` suffix is appended because the FastMCP application is mounted at that path (`webapp.py:19`) — the resource identifier must include the path component the resource actually lives at.
+
+**Alternatives:**
+- Leave `resource_url` as `None` and skip the `resource` field: violates RFC 9728 §4.1 (field REQUIRED).
+- Use `127.0.0.1` as default: incorrect for remote-transport deployments.
+- Omit the `/mcp` suffix: the metadata's `resource` field would no longer identify the actual resource location, and the well-known path would land at origin root instead of the RFC-canonical scoped location.
+
+**Binding:** `create_app()` MUST pass the resolved bind base URL **plus the FastMCP mount path** into `OAuthConfig` (or into a `resource_url` resolver) so the route handler can read it from config, not re-derive it at request time. The mount path SHALL be sourced from the same constant used in `webapp.py` (currently `"/mcp"`), not duplicated as a literal — if the mount path ever changes, the resource URL follows.
+
+### Decision: no-resource-url-override
+
+**Choice:** Do not introduce a `HYDROLIX_OAUTH_RESOURCE_URL` env var. `OAuthConfig.resource_url` is resolved only from `HYDROLIX_URL` (with bind-URL fallback), always with `/mcp` appended.
+
+**Why:** `resource_url` participates in nothing structural — it is only advertised in the RFC 9728 JSON `resource` field, used to derive the well-known path per RFC 9728 §3, and used to build the `WWW-Authenticate: resource_metadata=` pointer. It does NOT gate token verification (that's `audience`), does NOT affect issuer matching, and does NOT affect activation. Across the supported deployment models (cluster, external/remote, stdio, local dev), every realistic resource identifier is `<HYDROLIX_URL>/mcp` — operators who need to advertise a different URL can simply set `HYDROLIX_URL` to that URL. Adding an override env var would create a fourth knob in the OAuth surface, a partial-config guard, and a "verbatim vs append" carveout in the precedence chain, all to support a deployment shape that does not exist in our supported set. YAGNI.
+
+**Alternatives:**
+- Keep `HYDROLIX_OAUTH_RESOURCE_URL` as an explicit operator override: rejected as YAGNI; complicates the precedence chain (verbatim vs append) and adds a partial-config guard, neither of which earns its keep.
+- Default `resource_url` to origin root (no `/mcp` suffix): rejected — the resource identifier should match where the MCP application actually lives, and dropping `/mcp` would also defeat the narrow-Traefik-rule rationale established in `path-scoped-well-known-per-rfc-9728`.
+
+**Binding:** `load_oauth_config()` SHALL NOT read any `HYDROLIX_OAUTH_RESOURCE_URL` env var. If a future deployment surfaces a genuine need for a custom advertised resource URL, an override env var can be added additively (non-breaking) by inserting a tier 0 ahead of the current chain.
+
+### Decision: www-authenticate-extension
+
+**Choice:** Extend the existing `WWW-Authenticate: Bearer` header on 401 responses with `resource_metadata="<url>"` where `<url>` is the absolute URL at which this worker actually serves the metadata document — same scheme/authority as `OAuthConfig.resource_url`, path `/.well-known/oauth-protected-resource` + `OAuthConfig.resource_url.path`. The string is computed once at `create_app()` time alongside route registration; the 401 handler reads it from config.
+
+**Why:** RFC 9728 §5.1 specifies this parameter as the mechanism for pointing clients to the metadata document. The existing 401 response path already constructs the `WWW-Authenticate` header; this is a one-field addition. Reusing the same source of truth as the route registration (`OAuthConfig.resource_url`) guarantees the pointer can never drift from where the document actually lives.
+
+**Alternatives:**
+- Add a separate `Link:` header: non-standard for OAuth; clients wouldn't know to look there.
+- Omit the parameter: allowed by RFC 9728 but degrades client discoverability.
+- Construct the URL from the request's `Host` header at 401-emit time: opens up Host-header spoofing as an attack on the discovery URL.
+
+**Binding:** The `WWW-Authenticate` header on every 401 from an authenticated endpoint MUST include `resource_metadata="<absolute-url>"`. The `<absolute-url>` MUST be derived from `OAuthConfig.resource_url` (same scheme/authority, well-known suffix inserted between authority and path component) — NOT from the request's `Host` header. There SHALL be exactly one canonical metadata URL per worker, identical to the URL the route is actually registered at.
+
+### Decision: traefik-allowlist-for-metadata
+
+**Choice:** Within a Hydrolix cluster deployment, the Traefik load balancer fronting the MCP worker MUST be updated (in the cluster-ops repo, not here) to allow unauthenticated `GET /.well-known/oauth-protected-resource/mcp` through to the worker, **routed to the MCP service** (Traefik fronts many services and we don't want this rule leaking to others). This change cannot enforce that itself; it can only document the dependency so the cluster-ops change ships in lockstep. This resolves the open question deferred from `oauth-config-and-preflight` (design.md "Traefik routing").
+
+**Why:** RFC 9728 §3 forbids protecting the metadata endpoint with the credentials it describes, but Hydrolix cluster Traefik instances front the worker and apply auth at the edge. If Traefik rejects the path before it reaches the worker, the endpoint is invisible to clients regardless of how it is registered in `create_app()` — the failure mode looks like a server bug but is an ingress-policy bug. The path-scoped placement (`/mcp` suffix) keeps the allowlist rule narrow enough that it does not affect any other service behind the same Traefik instance. See `path-scoped-well-known-per-rfc-9728` above for why the path is scoped rather than at origin root.
+
+**Alternatives:**
+- Rely on Traefik defaulting to permissive: not the case for cluster deployments; auth-at-edge is the norm.
+- Serve the metadata document from Traefik itself: drifts from `OAuthConfig.resource_url`/`issuer` resolution and duplicates state.
+- Broad allowlist at `/.well-known/oauth-protected-resource` (no `/mcp` suffix): would also allow unauthenticated traffic to any future neighboring service's protected-resource-metadata endpoint, defeating the per-service scoping.
+
+**Binding:** The PR description for this change MUST link to (or block on) the corresponding cluster-ops change that adds a Traefik allowlist rule with both an **exact path match** on `/.well-known/oauth-protected-resource/mcp` and a **service match** routing to the MCP worker. Stdio-transport deployments and standalone worker deployments are not affected.
+
+## Risks / Trade-offs
+
+- [Risk] Bind-URL fallback requires host+port from server config inside `create_app()` → `create_app()` already receives this config; no new coupling needed.
+- [Risk] Unauthenticated endpoint used for SSRF fingerprinting → document is static and contains only the public issuer URL; risk negligible.
+- [Risk] Cluster Traefik rejects `/.well-known/oauth-protected-resource/mcp` before it reaches the worker → out-of-repo dependency; see `traefik-allowlist-for-metadata` decision above. Mitigation: ship the Traefik rule alongside this change and add a post-deploy smoke check that the path returns 200 unauthenticated from outside the cluster.
+- [Risk] Strict RFC-9728 clients that bypass `WWW-Authenticate`-driven discovery and probe origin root `/.well-known/oauth-protected-resource` will see 404 → acceptable per `path-scoped-well-known-per-rfc-9728`: the path-scoped location is the RFC-canonical one for a resource identified by `<base>/mcp`. Clients following RFC 9728 §3 derivation arrive at the correct path; clients following the `WWW-Authenticate: resource_metadata=` pointer always get the absolute URL.
+
+## Open Questions
+
+*none*

--- a/openspec/changes/oauth-resource-metadata/explore.md
+++ b/openspec/changes/oauth-resource-metadata/explore.md
@@ -1,0 +1,10 @@
+*This change was formed before openspec introduced `explore.md` as a required artifact. No genuine pre-spec audit trail exists; the substantive design choices are recorded in `design.md`. The Q&A below disambiguates one point that an independent reviewer might otherwise misread.*
+
+## Decisions
+
+### Decision: this-spec-owns-resource-url-field
+
+- **Question**: `OAuthConfig` is established by `oauth-config-and-preflight`, but this change adds a new field `resource_url` to it. Why does field ownership cross the change boundary?
+- **Answer**: Each change contributes only the `OAuthConfig` fields that the requirements it owns actually consume. `oauth-config-and-preflight` establishes the dataclass with the fields needed for activation gating and preflight (`issuer`, `audience`, `required_scopes`, `jwks_uri`, `allow_insecure_jwks`). It deliberately does NOT include `resource_url`, because resource_url is consumed only by the RFC 9728 metadata endpoint owned here. Keeping field ownership co-located with its requirement makes the field's tests live next to its consumer; an implementer touching the RFC 9728 endpoint also touches the field, and an implementer touching the activation gate does not.
+- **Rationale**: One-place-for-each-thing review hygiene at the field level, not just the requirement level.
+- **Affects**: tasks.md task 1.1 (adds the field to the dataclass); design.md note about field provenance.

--- a/openspec/changes/oauth-resource-metadata/proposal.md
+++ b/openspec/changes/oauth-resource-metadata/proposal.md
@@ -1,0 +1,40 @@
+*Expose the RFC 9728 protected-resource-metadata endpoint and resolve the resource URL from operator configuration.*
+
+## Why
+
+MCP clients that implement OAuth discovery need a standards-compliant `/.well-known/oauth-protected-resource` document to locate the authorization server and construct token requests. Without it, clients must be configured out-of-band. The resource URL that populates the `resource` field is derived from `HYDROLIX_URL` (with a bind-URL fallback) because the public cluster URL differs from the address the MCP worker binds to.
+
+## Family Context / Forward References
+
+One of 5 changes decomposing OAuth bearer authentication for [HDX-11442](https://hydrolix.atlassian.net/browse/HDX-11442). All five target the shared capability `oauth-authentication`. Dependency order:
+
+- `oauth-config-and-preflight` — root of the dep graph; this change consumes `OAuthConfig.issuer` from it.
+- `oauth-resource-metadata` (this change) — depends on `oauth-config-and-preflight`.
+- `oauth-jwt-verifier` — depends on `oauth-config-and-preflight`.
+- `oauth-auth-chain-and-activation` — depends on `oauth-jwt-verifier`.
+- `oauth-log-redaction` — orthogonal.
+
+## What Changes
+
+- A `GET /.well-known/oauth-protected-resource/mcp` endpoint is available when OAuth is active, returning an RFC 9728 JSON document; returns 404 when OAuth is inactive. The path is the RFC 9728 §3 canonical location for a resource identified by `<base>/mcp` (well-known suffix inserted between authority and resource path).
+- The endpoint is reachable without authentication (RFC 9728 §3 requirement).
+- HTTP 401 responses on authenticated endpoints include a `resource_metadata` pointer to the metadata endpoint in their `WWW-Authenticate` header (requires `oauth-jwt-verifier` or `oauth-auth-chain-and-activation` to be landed; the metadata endpoint itself is independently exercisable).
+- `OAuthConfig.resource_url` is resolved from a two-tier precedence chain (`HYDROLIX_URL` + `/mcp` → server bind URL + `/mcp`). The `/mcp` suffix is the FastMCP mount path (`webapp.py:19`), sourced from the same constant in code. No env-var override is provided in this change — `resource_url` is purely advertised in discovery surfaces (RFC 9728 JSON + `WWW-Authenticate` pointer) and does not gate token verification, so a dedicated override would be YAGNI given the supported deployment models. An override env var can be added additively later if a real need surfaces.
+
+## Capabilities
+
+### New
+
+*none*
+
+### Modified
+
+- `oauth-authentication` — adds the RFC 9728 protected-resource-metadata endpoint and the two-tier resource URL precedence chain (`HYDROLIX_URL` + `/mcp` → server bind URL + `/mcp`)
+
+## Impact
+
+- **mcp_hydrolix/auth/oauth.py**: `OAuthConfig` and `load_oauth_config()`
+- **mcp_hydrolix/webapp.py**: route registration and 401 response headers
+- **tests/test_oauth_resource_metadata.py**: new test module
+- **Upstream dependency**: `oauth-config-and-preflight` must land first
+- **Hydrolix cluster deployment (out-of-repo)**: Traefik fronts many services in the cluster, so the new ingress rule must be **narrowly scoped**: exact path match on `/.well-known/oauth-protected-resource/mcp`, routed to the MCP service, allowing unauthenticated `GET`. Without this rule Traefik will reject discovery requests before they reach the application; with a broader rule the unauthenticated path would leak to neighboring services. This must be coordinated with the o6r / cluster ops change that ships alongside this code. Resolves the Traefik open question deferred from `oauth-config-and-preflight`.

--- a/openspec/changes/oauth-resource-metadata/specs/oauth-authentication/spec.md
+++ b/openspec/changes/oauth-resource-metadata/specs/oauth-authentication/spec.md
@@ -1,0 +1,70 @@
+*RFC 9728 protected-resource-metadata endpoint and resource URL precedence chain, active only when OAuth is enabled.*
+
+## ADDED Requirements
+
+### Requirement: RFC 9728 Protected Resource Metadata Endpoint
+
+When OAuth is active (as defined by `oauth-config-and-preflight`), the server SHALL expose an unauthenticated `GET` endpoint serving a JSON document conforming to [RFC 9728](https://www.rfc-editor.org/rfc/rfc9728). The endpoint path SHALL be `/.well-known/oauth-protected-resource` concatenated with the path component of `OAuthConfig.resource_url`, per RFC 9728 §3 (well-known suffix inserted between authority and resource path). Because the MCP application is mounted at `/mcp` (see `webapp.py`), and the resource URL precedence chain (see "Resource URL Configuration") produces a `resource_url` whose path component is `/mcp` for all non-operator-overridden tiers, the canonical endpoint path is **`/.well-known/oauth-protected-resource/mcp`**.
+
+The endpoint SHALL NOT require authentication. The JSON body SHALL include at minimum:
+
+- `resource`: the value of `OAuthConfig.resource_url` after the precedence chain defined in "Resource URL Configuration".
+- `authorization_servers`: a JSON array containing exactly the resolved issuer URL (`OAuthConfig.issuer` as set by `oauth-config-and-preflight`).
+- `bearer_methods_supported`: a JSON array containing at least `"header"`.
+
+When OAuth is inactive, a `GET` request to the metadata endpoint path SHALL return HTTP 404.
+
+When a request to an authenticated endpoint is rejected with HTTP 401, the `WWW-Authenticate` response header SHALL include a `resource_metadata="<url>"` parameter whose value is the absolute URL of the protected-resource-metadata endpoint as actually served by this worker — i.e. the same scheme/authority used for `OAuthConfig.resource_url` concatenated with `/.well-known/oauth-protected-resource` and the path component of `OAuthConfig.resource_url`. For the default `HYDROLIX_URL`-based config this resolves to `<HYDROLIX_URL>/.well-known/oauth-protected-resource/mcp`.
+
+#### Scenario: Metadata Endpoint Returns RFC 9728 JSON At Path-Scoped Location
+
+- **WHEN** OAuth is active with `HYDROLIX_URL="https://cluster.example.com"` (so `OAuthConfig.resource_url == "https://cluster.example.com/mcp"`) and an unauthenticated GET request is made to `/.well-known/oauth-protected-resource/mcp`
+- **THEN** the response status SHALL be 200
+- **AND** the `Content-Type` header SHALL be `application/json`
+- **AND** the response body SHALL be valid JSON containing `resource`, `authorization_servers`, and `bearer_methods_supported` keys
+- **AND** `authorization_servers` SHALL be an array containing `OAuthConfig.issuer`
+- **AND** `resource` SHALL equal `"https://cluster.example.com/mcp"`
+
+#### Scenario: Worker Does Not Claim Root Well-Known Path
+
+- **WHEN** OAuth is active with `HYDROLIX_URL="https://cluster.example.com"` and a GET request to `/.well-known/oauth-protected-resource` (root, no `/mcp` suffix) reaches **this worker** directly (e.g. in an isolated test or a direct in-cluster hit, not through ingress)
+- **THEN** this worker SHALL respond 404 — it does not register a handler for the origin root path
+
+This scenario constrains worker behavior only. It does NOT require the cluster as a whole to return 404 at that path: the origin root `/.well-known/oauth-protected-resource` is deliberately left unclaimed by the MCP worker so that a future, broader-scoped service (e.g. one whose resource identifier has no path component) MAY claim it via cluster routing without conflicting with this worker.
+
+#### Scenario: 401 References Path-Scoped Metadata URL
+
+- **WHEN** `HYDROLIX_OAUTH_AUDIENCE="mcp-test"` and `HYDROLIX_OAUTH_ISSUER="https://idp.example.com/realms/test"` are set, OAuth is active (and an auth chain capable of emitting 401 is present, i.e. `oauth-jwt-verifier` or `oauth-auth-chain-and-activation` has landed), and a GET request to `/mcp/tools/list` arrives with an invalid bearer token
+- **THEN** the `WWW-Authenticate` response header SHALL include a `resource_metadata=` parameter
+- **AND** the parameter value SHALL be the absolute URL of the path-scoped metadata endpoint (i.e. ending in `/.well-known/oauth-protected-resource/mcp`)
+
+#### Scenario: Metadata Endpoint Returns 404 When OAuth Inactive
+
+- **WHEN** OAuth is inactive (no `HYDROLIX_OAUTH_AUDIENCE` set) and a GET request is made to `/.well-known/oauth-protected-resource/mcp`
+- **THEN** the response status SHALL be 404
+
+### Requirement: Resource URL Configuration
+
+The `resource` field in the RFC 9728 document SHALL be resolved from `OAuthConfig.resource_url` using the following two-tier precedence chain. Both tiers SHALL append the FastMCP mount path (`/mcp`, as configured in `webapp.py`) so the resulting `resource_url` identifies the MCP application as a path-scoped resource per RFC 9728 §3.
+
+1. If `HYDROLIX_URL` is set to a non-empty value, the resource URL SHALL be `HYDROLIX_URL` with `/mcp` appended (collapsing any duplicate or trailing slash).
+2. Otherwise, the resource URL SHALL default to the server's configured base URL (scheme + host + port that the worker is bound to) with `/mcp` appended.
+
+There is deliberately no operator override env var for `resource_url`. `resource_url` is purely advertised in the RFC 9728 metadata document and in the `WWW-Authenticate: resource_metadata=` pointer — it does not participate in server-side token verification, issuer matching, JWKS URI selection, or activation logic. Any operator who needs to advertise a different URL than `<HYDROLIX_URL>/mcp` can set `HYDROLIX_URL` to that URL; a dedicated override would be additive and non-breaking to introduce later if a deployment need actually emerges.
+
+#### Scenario: Resource URL Defaults To Hydrolix URL Plus Mount Path
+
+- **WHEN** `HYDROLIX_URL="https://cluster.example.com"` is set, OAuth is active, and `OAuthConfig.resource_url` is resolved
+- **THEN** `OAuthConfig.resource_url` SHALL equal `"https://cluster.example.com/mcp"`
+- **AND** the `resource` field in the RFC 9728 JSON SHALL equal `"https://cluster.example.com/mcp"`
+
+#### Scenario: Resource URL Defaults To Hydrolix URL With Trailing Slash Plus Mount Path
+
+- **WHEN** `HYDROLIX_URL="https://cluster.example.com/"` is set, OAuth is active, and `OAuthConfig.resource_url` is resolved
+- **THEN** `OAuthConfig.resource_url` SHALL equal `"https://cluster.example.com/mcp"` (single slash, no duplicate)
+
+#### Scenario: Resource URL Falls Back To Server Bind URL Plus Mount Path
+
+- **WHEN** `HYDROLIX_URL` is unset, OAuth is active with an explicit `HYDROLIX_OAUTH_ISSUER`, and `OAuthConfig.resource_url` is resolved
+- **THEN** `OAuthConfig.resource_url` SHALL equal the server's bound base URL (scheme + host + port) with `/mcp` appended
+- **AND** the `resource` field in the RFC 9728 JSON SHALL equal that value

--- a/openspec/changes/oauth-resource-metadata/tasks.md
+++ b/openspec/changes/oauth-resource-metadata/tasks.md
@@ -1,0 +1,33 @@
+*3 phases, 12 tasks: config extension, route registration, and test coverage.*
+
+## 1. Config Extension
+
+- [ ] 1.1 Add `resource_url` field to `OAuthConfig`: add a `resource_url: str` field to the `OAuthConfig` dataclass in `mcp_hydrolix/auth/oauth.py` [implements: oauth-authentication/resource-url-configuration, design/resource-url-bind-url-fallback] — verify: `ruff check mcp_hydrolix/auth/oauth.py` clean and `mypy mcp_hydrolix/auth/oauth.py` passes
+
+- [ ] 1.2 Implement two-tier precedence in `load_oauth_config()`: resolve `resource_url` from (1) `HYDROLIX_URL` with `/mcp` appended (collapsing any trailing slash), or (2) the bind base URL (passed in as a parameter) with `/mcp` appended; assign to `OAuthConfig.resource_url`. Source the `/mcp` literal from the same constant used by `webapp.py` for the FastMCP mount, not a duplicated string. Do NOT read any `HYDROLIX_OAUTH_RESOURCE_URL` env var (see `no-resource-url-override` design decision) [implements: oauth-authentication/resource-url-configuration, design/resource-url-bind-url-fallback, design/no-resource-url-override] — verify: `ruff check mcp_hydrolix/auth/oauth.py` clean
+
+## 2. Route and Header Registration
+
+- [ ] 2.1 Register path-scoped metadata route in `create_app()`: add an unauthenticated GET handler on the ASGI app at the path `/.well-known/oauth-protected-resource` + `urlparse(OAuthConfig.resource_url).path` (i.e. `/.well-known/oauth-protected-resource/mcp` for the default chain), returning the RFC 9728 JSON document (`resource`, `authorization_servers`, `bearer_methods_supported`) when OAuth is active; register no route when OAuth is inactive so the path returns 404 via the default not-found handler. The handler MUST be registered before any auth middleware [implements: oauth-authentication/rfc-9728-protected-resource-metadata-endpoint, design/path-scoped-well-known-per-rfc-9728] — verify: `ruff check mcp_hydrolix/webapp.py` clean
+
+- [ ] 2.2 Pass bind base URL into `load_oauth_config()` from `create_app()`: update the `create_app()` call site to derive the bind base URL (scheme + host + port from uvicorn/server config) and pass it to `load_oauth_config()` for the bind-URL fallback in task 1.2 [implements: oauth-authentication/resource-url-configuration, design/resource-url-bind-url-fallback] — verify: `ruff check mcp_hydrolix/webapp.py` clean
+
+- [ ] 2.3 Compute the canonical metadata absolute URL once in `create_app()`: derive `metadata_url = <resource_url scheme+authority> + "/.well-known/oauth-protected-resource" + urlparse(resource_url).path` from `OAuthConfig.resource_url`, store it on config (or a small companion struct) so both the route handler and the 401 path read the same value [implements: design/www-authenticate-extension] — verify: `ruff check mcp_hydrolix/webapp.py` clean
+
+- [ ] 2.4 Extend `WWW-Authenticate` 401 header with `resource_metadata=`: update the 401 response path to append `resource_metadata="<metadata_url>"` to the `WWW-Authenticate: Bearer` header, reading the precomputed `metadata_url` from config (task 2.3). MUST NOT construct the URL from the request's `Host` header [implements: oauth-authentication/rfc-9728-protected-resource-metadata-endpoint, design/www-authenticate-extension] — verify: `ruff check mcp_hydrolix/` clean
+
+## 3. Test Coverage
+
+- [ ] 3.1 Add test for scenario "Metadata Endpoint Returns RFC 9728 JSON At Path-Scoped Location" [implements: oauth-authentication/rfc-9728-protected-resource-metadata-endpoint, meta/tests] — verify: `pytest -q tests/test_oauth_resource_metadata.py::test_metadata_endpoint_returns_rfc_9728_json_at_path_scoped_location` green
+
+- [ ] 3.2 Add test for scenario "Worker Does Not Claim Root Well-Known Path" (asserts the worker itself returns 404 at `/.well-known/oauth-protected-resource` with no `/mcp` suffix in default config — worker-scope only, not a cluster-wide assertion) [implements: oauth-authentication/rfc-9728-protected-resource-metadata-endpoint, design/path-scoped-well-known-per-rfc-9728, meta/tests] — verify: `pytest -q tests/test_oauth_resource_metadata.py::test_worker_does_not_claim_root_well_known_path` green
+
+- [ ] 3.3 Add test for scenario "401 References Path-Scoped Metadata URL" [implements: oauth-authentication/rfc-9728-protected-resource-metadata-endpoint, design/www-authenticate-extension, meta/tests] — verify: `pytest -q tests/test_oauth_resource_metadata.py::test_401_references_path_scoped_metadata_url` green
+
+- [ ] 3.4 Add test for scenario "Metadata Endpoint Returns 404 When OAuth Inactive" [implements: oauth-authentication/rfc-9728-protected-resource-metadata-endpoint, meta/tests] — verify: `pytest -q tests/test_oauth_resource_metadata.py::test_metadata_endpoint_returns_404_when_oauth_inactive` green
+
+- [ ] 3.5 Add test for scenario "Resource URL Defaults To Hydrolix URL Plus Mount Path" [implements: oauth-authentication/resource-url-configuration, meta/tests] — verify: `pytest -q tests/test_oauth_resource_metadata.py::test_resource_url_defaults_to_hydrolix_url_plus_mount_path` green
+
+- [ ] 3.6 Add test for scenario "Resource URL Defaults To Hydrolix URL With Trailing Slash Plus Mount Path" (asserts single slash, no duplicate) [implements: oauth-authentication/resource-url-configuration, meta/tests] — verify: `pytest -q tests/test_oauth_resource_metadata.py::test_resource_url_defaults_to_hydrolix_url_with_trailing_slash_plus_mount_path` green
+
+- [ ] 3.7 Add test for scenario "Resource URL Falls Back To Server Bind URL Plus Mount Path" [implements: oauth-authentication/resource-url-configuration, meta/tests] — verify: `pytest -q tests/test_oauth_resource_metadata.py::test_resource_url_falls_back_to_server_bind_url_plus_mount_path` green


### PR DESCRIPTION
What does this PR do?
-----------------------

Builds on oauth-config-and-preflight. Part 2 of the 5-change decomposition for [HDX-11442](https://hydrolix.atlassian.net/browse/HDX-11442).

Modifies the `oauth-authentication` capability to add:
- RFC 9728 /.well-known/oauth-protected-resource endpoint (unauthenticated; exposed only when OAuth is active -- scoped in a cluster to the /mcp route).
- Resource-URL precedence: HYDROLIX_URL-derived (prod) > server bind URL-derived (dev).
- Conditional WWW-Authenticate resource_metadata= parameter (attaches when a 401-emitting path has landed; the metadata endpoint itself works standalone).

Drops `HYDROLIX_OAUTH_RESOURCE_URL` (unnecessary)

Dependency position: depends on oauth-config-and-preflight (consumes OAuthConfig.issuer; this change adds resource_url to the dataclass).

Does this PR meet the acceptance criteria?
--------------------------------------------

* [x] Documentation created/updated
* [ ] Tests added for this feature/bug
* [ ] Does this change request have any security impacts?

Release Notes
---------------------------------------------------

* Major changes:
    *
* Minor changes:
    *
* Bugfixes:
    *
* Issues Closed:
    *
* Security impacts identified:
    *

Testing
--------------------------------------------


[HDX-11442]: https://hydrolix.atlassian.net/browse/HDX-11442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ