### PR TITLE
[IL][HDX-11442][Spec] OAuth JWT verification module

### DIFF
--- a/openspec/changes/oauth-jwt-verifier/.openspec.yaml
+++ b/openspec/changes/oauth-jwt-verifier/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: interactive-spec-led
+created: 2026-05-27

--- a/openspec/changes/oauth-jwt-verifier/design.md
+++ b/openspec/changes/oauth-jwt-verifier/design.md
@@ -1,0 +1,67 @@
+*Pure claim validation layer: iss-based routing for chain composability, issuer exact-match, audience allowlist, optional scope enforcement, and end-to-end bearer acceptance — no I/O at request time.*
+
+## Context
+
+- `OAuthConfig` (from `oauth-config-and-preflight`) delivers `issuer`, `audience`, and `required_scopes` as already-validated values.
+- SA bearer tokens are JWTs (`iss = {HYDROLIX_URL}/config`) sharing the `Authorization: Bearer` header; `canonical_idp_endpoints` ([HDX-11441](https://hydrolix.atlassian.net/browse/HDX-11441)) guarantees `OAuthConfig.issuer != HYDROLIX_URL`.
+- This change produces an `OAuthHydrolixAuthProvider` instance that returns an `OAuthBearerToken` on success or `None` on deferral. Downstream the chain-activation change consumes this provider, but understanding this spec doesn't require reading that one.
+
+## Goals / Non-Goals
+
+**Goals:**
+- iss-based routing.
+- Issuer exact-match.
+- Audience allowlist.
+- Required-scopes enforcement.
+- End-to-end bearer acceptance.
+
+**Non-Goals:**
+- Refresh-token, introspection, DPoP.
+- Parsing env vars.
+- Composing with SA chain.
+- Startup conflation check.
+
+## Decisions
+
+### Decision: iss-based-routing-for-chain-composability
+
+- **Choice:** `OAuthHydrolixAuthProvider` peeks `iss` without signature verification. If `iss` matches the resolved OAuth issuer URL, it claims the bearer; otherwise returns `None` and defers.
+- **Why:** SA tokens share the `Authorization: Bearer` header. Without routing, the OAuth verifier would consume them, signature check would fail, and SA auth would break. The `iss` claim is the only reliable discriminator; the unverified peek is routing-only.
+- **Alternatives:**
+    - Shape-based detection via JWT header `alg` — rejected; SA and OAuth tokens may share the same algorithm.
+    - "Just try it" fall-through — rejected; a token claimed by one auth protocol must not be accidentally accepted by another auth protocol
+- **Binding:** `OAuthHydrolixAuthProvider` MUST extract `iss` without signature verification before dispatching. A non-JWT-shaped bearer MUST be deferred (`None`), not rejected.
+- **Note on unknown-issuer tokens:** A token whose `iss` matches neither the OAuth issuer nor the SA `iss` shape defers silently from this verifier — no log line is emitted here. Final-outcome handling for a bearer that defers through the entire chain (likely a deployment / IdP-misconfiguration signal rather than an unauthorized login attempt) is owned by `oauth-auth-chain-and-activation`, which has end-to-end visibility into "no backend claimed this bearer." This change deliberately stays silent on deferral so the chain owner can emit one well-scoped WARNING rather than N per-backend log lines.
+
+### Decision: non-conflation-as-verifier-invariant
+
+- **Choice:** Non-conflation is enforced by the routing predicate: `iss = HYDROLIX_URL` won't match `OAuthConfig.issuer`, so the OAuth verifier defers and no backend claims it; the chain returns 401.
+- **Why:** A startup check duplicates the guarantee `canonical_idp_endpoints` already provides (`OAuthConfig.issuer != HYDROLIX_URL`) — no added security, just unnecessary coupling to the `HYDROLIX_URL` env-var surface.
+- **Alternatives:** Startup check raising `OAuthConfigError` — rejected; couples this module to `HYDROLIX_URL` env state.
+- **Binding:** `OAuthHydrolixAuthProvider` MUST NOT reference `HYDROLIX_URL`. Non-conflation MUST be tested with a hardcoded cluster URL as `iss`, asserting 401 independent of env state.
+
+### Decision: audience-as-set-intersection
+
+- **Choice:** A JWT is accepted if any value in its `aud` claim (normalized to a set) intersects `OAuthConfig.audience`.
+- **Why:** JWTs may carry a single `aud` string or an array; the allowlist is comma-separated. Set intersection handles both.
+- **Alternatives:** Require all allowlist values in `aud` — rejected; not standard OIDC practice.
+- **Binding:** MUST accept when any `aud` value is in the allowlist; MUST reject when none are.
+
+### Decision: scope-claim-union
+
+- **Choice:** Scope enforcement checks both `scope` (space-delimited) and `scp` (array); all configured scopes must be present via either claim.
+- **Why:** IdPs vary in scope claim name; supporting both avoids IdP-specific config.
+- **Alternatives:** Check only `scope` or only `scp` — rejected; each breaks a major IdP family.
+- **Binding:** When `required_scopes` is non-empty, MUST accept via `scope` or `scp`. If neither present, MUST reject.
+
+### Decision: no-io-at-request-time
+
+- **Choice:** Pure in-memory claim validation; JWKS key material loaded at startup and cached.
+- **Why:** JWKS prefetch is `oauth-config-and-preflight`'s responsibility; per-request I/O adds latency outside scope.
+- **Alternatives:** Lazy JWKS fetch per request — rejected; duplicates preflight and adds latency.
+- **Binding:** `OAuthHydrolixAuthProvider` MUST NOT make outbound calls at request time. JWKS MUST be provided at construction.
+
+## Risks / Trade-offs
+
+- Clock skew: verified that FastMCP `JWTVerifier` (3.3.0, `fastmcp/server/auth/providers/jwt.py`) accepts no `leeway` parameter on `__init__` and applies none internally (PyJWT default 0; hand-rolled `exp < time.time()` check has no tolerance either). Clients with skewed clocks against the IdP will see spurious 401s near token expiry. This is **unmitigated by this change**; a follow-up would have to extend FastMCP itself (or wrap its verify call) to add tolerance. Out of scope here.
+- JWKS key rotation: out of scope; worker restart required to pick up rotated keys.

--- a/openspec/changes/oauth-jwt-verifier/explore.md
+++ b/openspec/changes/oauth-jwt-verifier/explore.md
@@ -1,0 +1,10 @@
+*This change was formed before openspec introduced `explore.md` as a required artifact. No genuine pre-spec audit trail exists; the substantive design choices are recorded in `design.md`. The Q&A below disambiguates one point that an independent reviewer might otherwise misread.*
+
+## Decisions
+
+### Decision: unverified-iss-peek-is-routing-only
+
+- **Question**: The OAuth verifier peeks the bearer JWT's `iss` claim **without** verifying the signature, then uses it to decide whether to claim the token or defer to the next backend. How is this not a security gap — couldn't an attacker forge `iss` to manipulate routing?
+- **Answer**: The unverified peek is used **only** for routing (which backend in the chain claims the bearer). Full JWKS signature verification still gates every success path. An attacker who sets `iss = <our-OAuth-issuer>` on a forged token: this verifier claims the bearer (`iss` matches) → JWKS signature check fails → 401. An attacker who sets `iss = <SA-issuer>`: this verifier defers → `BearerAuthBackend` (the SA verifier) attempts its own signature check against the SA public key → fails → 401. Either way the request is rejected. The peek influences routing only, not authentication; no codepath grants access based on the unverified claim.
+- **Rationale**: Hydrolix service-account bearer tokens are themselves JWTs and share the `Authorization: Bearer` header. Routing has to happen somewhere; doing it via the `iss` claim mirrors the upstream `turbine-api` [`TokenValidator.validate_token`](https://github.com/hydrolix/turbine/blob/0f072549d775ae8d6384fabcb26fe3c224a719f5/turbine-api/common/rest_framework/authentication/token_validator.py#L115-L137)'s own dispatch strategy and aligns the two systems' routing semantics.
+- **Affects**: `OAuthHydrolixAuthProvider`'s claim/defer/raise contract; the **OAuth Verifier Claims Bearers By Iss Match** requirement in spec.md.

--- a/openspec/changes/oauth-jwt-verifier/proposal.md
+++ b/openspec/changes/oauth-jwt-verifier/proposal.md
@@ -1,0 +1,44 @@
+*Bearer tokens issued by the configured OAuth provider are now validated for issuer, audience, required scopes, and signature before MCP tool dispatch; tokens from other issuers are passed through to the SA credential chain unchanged.*
+
+## Why
+
+Cluster operators need a way to gate MCP tool access on OIDC-issued bearer tokens. The core verifier — iss-based routing, issuer match, audience allowlist, required scopes, and signature check — is the independently reviewable piece that downstream composition (`oauth-auth-chain-and-activation`) mounts into the request path. Separating it from configuration parsing (`oauth-config-and-preflight`) and chain assembly makes each piece auditable in isolation.
+
+## Family Context / Forward References
+
+One of 5 changes decomposing OAuth bearer authentication for [HDX-11442](https://hydrolix.atlassian.net/browse/HDX-11442). All five target the shared capability `oauth-authentication`. Dependency order:
+
+- `oauth-config-and-preflight` — root of the dep graph; this change consumes `OAuthConfig.issuer`, `audience`, and `required_scopes` from it.
+- `oauth-resource-metadata` — this change consumes its precomputed metadata URL for the `resource_metadata=` parameter on 401s.
+- `oauth-jwt-verifier` (this change) — depends on `oauth-config-and-preflight`.
+- `oauth-auth-chain-and-activation` — depends on this change (composes `OAuthHydrolixAuthProvider` with the SA chain).
+- `oauth-log-redaction` — orthogonal.
+
+## What Changes
+
+- OAuth bearer tokens are routed to the OAuth verifier by `iss` claim; service-account bearers are deferred to the SA backend (iss-based routing for chain composability).
+- JWTs with an issuer that does not match the configured OAuth issuer URL are rejected with 401.
+- JWTs with no `aud` value in the configured audience allowlist are rejected with 401.
+- JWTs missing a required scope (when scopes are configured) are rejected with 401.
+- Well-formed bearers satisfying all claim checks are authenticated and dispatched to the MCP tool layer.
+
+## Capabilities
+
+### New
+
+*none*
+
+### Modified
+
+- `oauth-authentication` — JWT claim validation:
+  - iss-based routing for chain composability.
+  - Signature/audience/scopes/expiry verification.
+  - Non-conflation invariant.
+  - End-to-end happy path.
+
+## Impact
+
+- `mcp_hydrolix/auth/oauth.py`: new verifier classes.
+- `fastmcp` `JWTVerifier`: integration point (existing dep from `oauth-config-and-preflight`).
+- `tests/auth/test_oauth_jwt_verifier.py`: new test module.
+- Downstream: `oauth-auth-chain-and-activation`.

--- a/openspec/changes/oauth-jwt-verifier/specs/oauth-authentication/spec.md
+++ b/openspec/changes/oauth-jwt-verifier/specs/oauth-authentication/spec.md
@@ -28,7 +28,7 @@ Three return modes:
 
 #### Scenario: Bearer With Service Account Issuer Is Deferred
 
-- **GIVEN** OAuth is active and a request presents a JWT whose `iss` ends in `/config`
+- **GIVEN** OAuth is active and a request presents a JWT whose `iss` ends in `/config` (i.e., a service account issuer)
 - **WHEN** `OAuthHydrolixAuthProvider` evaluates the bearer
 - **THEN** the OAuth verifier SHALL return `None` without raising
 - **AND** SHALL emit no log line for the deferral
@@ -43,7 +43,7 @@ Three return modes:
 
 ### Requirement: JWT Verification Rejects Mismatched Issuer
 
-The verifier enforces a non-conflation invariant: `iss` exact-match makes it structurally impossible for a token with `iss = HYDROLIX_URL` to be claimed (since `canonical_idp_endpoints` guarantees `issuer != HYDROLIX_URL`). The scenarios below make this testable independent of real env state. `OAuthHydrolixAuthProvider` MUST NOT reference `HYDROLIX_URL`.
+The verifier enforces a non-conflation invariant: `iss` exact-match makes it structurally impossible for a token with `iss = HYDROLIX_URL` to be claimed (since `canonical_idp_endpoints` guarantees `issuer != HYDROLIX_URL`). The scenarios below make this testable independent of real env state. `OAuthHydrolixAuthProvider` MUST NOT reference `HYDROLIX_URL` directly (only `OAuthConfig.issuer`).
 
 #### Scenario: Token Uses Cluster Url As Issuer
 

--- a/openspec/changes/oauth-jwt-verifier/specs/oauth-authentication/spec.md
+++ b/openspec/changes/oauth-jwt-verifier/specs/oauth-authentication/spec.md
@@ -1,0 +1,107 @@
+*Pure claim validation for OAuth bearer tokens: iss-based routing for chain composability, issuer exact-match, audience allowlist, required scopes, and end-to-end bearer acceptance.*
+
+## ADDED Requirements
+
+### Requirement: OAuth Verifier Claims Bearers By Iss Match
+
+`OAuthHydrolixAuthProvider` SHALL act as a chain-composable backend, claiming a bearer iff its `iss` claim exactly matches the resolved OAuth issuer URL, otherwise deferring. The `iss` peek occurs without signature verification (routing only); full verification still gates every success path.
+
+Three return modes:
+1. `iss` matches + verification succeeds → return authenticated principal.
+2. `iss` matches + verification fails → raise 401 with `WWW-Authenticate: Bearer realm=…, resource_metadata=<rfc9728-url>`.
+3. `iss` does not match, OR bearer is not JWT-shaped → return `None` (defer). No log line, no 401.
+
+#### Scenario: Bearer With Oauth Issuer And Valid Signature Is Accepted
+
+- **GIVEN** OAuth is active and a request presents a JWT whose `iss` equals the resolved OAuth issuer
+- **WHEN** the JWT's signature verifies against the JWKS and its other claims are well-formed
+- **THEN** the verifier SHALL return an authenticated principal
+- **AND** the chain SHALL stop without consulting subsequent backends
+
+#### Scenario: Bearer With Oauth Issuer And Invalid Signature Is Rejected With 401
+
+- **GIVEN** OAuth is active and a request presents a JWT whose `iss` equals the resolved OAuth issuer
+- **WHEN** the JWT's signature does not verify
+- **THEN** the verifier SHALL raise 401
+- **AND** the response SHALL include `WWW-Authenticate: Bearer` with a `resource_metadata=<url>` parameter
+- **AND** the chain SHALL NOT consult subsequent backends
+
+#### Scenario: Bearer With Service Account Issuer Is Deferred
+
+- **GIVEN** OAuth is active and a request presents a JWT whose `iss` ends in `/config`
+- **WHEN** `OAuthHydrolixAuthProvider` evaluates the bearer
+- **THEN** the OAuth verifier SHALL return `None` without raising
+- **AND** SHALL emit no log line for the deferral
+- **AND** the next backend in the chain SHALL receive the request
+
+#### Scenario: Malformed Bearer Is Deferred
+
+- **GIVEN** OAuth is active and a request presents a bearer value that is not a JWT
+- **WHEN** `OAuthHydrolixAuthProvider` evaluates the bearer
+- **THEN** the OAuth verifier SHALL return `None` without raising
+- **AND** the next backend in the chain SHALL receive the request
+
+### Requirement: JWT Verification Rejects Mismatched Issuer
+
+The verifier enforces a non-conflation invariant: `iss` exact-match makes it structurally impossible for a token with `iss = HYDROLIX_URL` to be claimed (since `canonical_idp_endpoints` guarantees `issuer != HYDROLIX_URL`). The scenarios below make this testable independent of real env state. `OAuthHydrolixAuthProvider` MUST NOT reference `HYDROLIX_URL`.
+
+#### Scenario: Token Uses Cluster Url As Issuer
+
+- **GIVEN** `OAuthConfig.issuer="https://idp.example.com/realms/hydrolix"` and `HYDROLIX_URL="https://cluster.example.com"` (if set)
+- **WHEN** a JWT is presented with `iss="https://cluster.example.com"`
+- **THEN** the chain rejects the request with 401
+
+#### Scenario: Derived Issuer Differs From Hydrolix Url Conflation Rejected
+
+- **GIVEN** OAuth has activated with issuer derived via `canonical_idp_endpoints(HYDROLIX_URL).issuer`
+- **WHEN** a JWT is presented with `iss="https://cluster.example.com"` (matching `HYDROLIX_URL`, not the derived issuer)
+- **THEN** the chain rejects the request with 401
+
+### Requirement: JWT Verification Rejects Mismatched Audience
+
+The verifier SHALL reject any JWT whose `aud` claim (normalized to a set) contains no value present in `OAuthConfig.audience`. Matching uses set intersection (see design decision `audience-as-set-intersection`).
+
+#### Scenario: Audience Not In Allowlist
+
+- **GIVEN** `OAuthConfig.audience={"mcp-hydrolix", "config-api"}`
+- **WHEN** a JWT is presented with `aud="some-other-service"`
+- **THEN** verification SHALL fail with 401
+
+#### Scenario: Second Allowlist Entry Matches
+
+- **GIVEN** `OAuthConfig.audience={"mcp-hydrolix", "config-api"}`
+- **WHEN** a JWT is presented with `aud="config-api"`
+- **THEN** verification SHALL succeed (other claims permitting)
+
+### Requirement: Required Scopes Enforced When Configured
+
+When `OAuthConfig.required_scopes` is non-empty, the verifier SHALL require every listed scope to appear in `scope` (space-delimited) or `scp` (array). If neither claim is present, the JWT SHALL be rejected. When `required_scopes` is empty, no scope check is performed (see design decision `scope-claim-union`).
+
+#### Scenario: Missing Required Scope
+
+- **GIVEN** `OAuthConfig.required_scopes={"read", "write"}`
+- **WHEN** a JWT is presented with `scope="read"` (missing `write`)
+- **THEN** verification SHALL fail with 401
+
+#### Scenario: All Required Scopes Present Via Scope Claim
+
+- **GIVEN** `OAuthConfig.required_scopes={"read", "write"}`
+- **WHEN** a JWT is presented with `scope="read write"`
+- **THEN** verification SHALL succeed (other claims permitting)
+
+#### Scenario: All Required Scopes Present Via Scp Claim
+
+- **GIVEN** `OAuthConfig.required_scopes={"read", "write"}`
+- **WHEN** a JWT is presented with `scp=["read", "write"]` and no `scope` claim
+- **THEN** verification SHALL succeed (other claims permitting)
+
+### Requirement: Valid Bearer Authenticates The Request End To End
+
+When OAuth is active, a JWT satisfying all of the following SHALL be authenticated and dispatched to the MCP tool layer: `iss` matches `OAuthConfig.issuer`; signature verifies against startup-loaded JWKS; `aud` intersects `OAuthConfig.audience`; `exp` in the future; all `required_scopes` present in `scope` or `scp`. No I/O beyond JWKS key lookup occurs at request time (see design decision `no-io-at-request-time`).
+
+#### Scenario: Well Formed Bearer Reaches The Mcp Tool Layer
+
+- **GIVEN** OAuth is active and JWKS key material has been loaded at startup
+- **WHEN** a request presents a JWT where signature verifies, `iss` equals `OAuthConfig.issuer`, `aud` contains a value in `OAuthConfig.audience`, `exp` is in the future, and required scopes (if any) are present
+- **THEN** the auth chain SHALL accept the request
+- **AND** the MCP tool SHALL be invoked and its response returned

--- a/openspec/changes/oauth-jwt-verifier/tasks.md
+++ b/openspec/changes/oauth-jwt-verifier/tasks.md
@@ -1,0 +1,43 @@
+*3 phases, 18 tasks: implement verifier (including iss-based routing), add scenario tests (13), verify docs and integration.*
+
+## 1. Core Implementation
+
+- [ ] 1.1 Add `OAuthBearerToken` dataclass to `mcp_hydrolix/auth/oauth.py` [implements: oauth-authentication/valid-bearer-authenticates-the-request-end-to-end, design/no-io-at-request-time] — verify: `ruff check mcp_hydrolix/auth/oauth.py` clean
+
+- [ ] 1.2 Add unverified `iss` peek in `OAuthHydrolixAuthProvider` (PyJWT `decode` with `verify_signature=False`); return `None` when `iss` doesn't match or bearer is not JWT-shaped; no log on deferral [implements: oauth-authentication/oauth-verifier-claims-bearers-by-iss-match, design/iss-based-routing-for-chain-composability] — verify: `ruff check mcp_hydrolix/auth/oauth.py` clean
+
+- [ ] 1.3 Add issuer exact-match check; no reference to `HYDROLIX_URL` inside this class [implements: oauth-authentication/jwt-verification-rejects-mismatched-issuer, design/non-conflation-as-verifier-invariant] — verify: `ruff check mcp_hydrolix/auth/oauth.py` clean
+
+- [ ] 1.4 Add audience set-intersection check: accept when any `aud` value intersects `OAuthConfig.audience` [implements: oauth-authentication/jwt-verification-rejects-mismatched-audience, design/audience-as-set-intersection] — verify: `ruff check mcp_hydrolix/auth/oauth.py` clean
+
+- [ ] 1.5 Add required-scopes check: all scopes must appear in `scope` (space-delimited) or `scp` (array); reject if neither present [implements: oauth-authentication/required-scopes-enforced-when-configured, design/scope-claim-union] — verify: `ruff check mcp_hydrolix/auth/oauth.py` clean
+
+## 2. Scenario Tests
+
+- [ ] 2.1 Test "Bearer With Oauth Issuer And Valid Signature Is Accepted" [implements: oauth-authentication/oauth-verifier-claims-bearers-by-iss-match, meta/tests] — verify: `pytest -q tests/auth/test_oauth_jwt_verifier.py::test_bearer_with_oauth_issuer_and_valid_signature_is_accepted` green
+
+- [ ] 2.2 Test "Bearer With Oauth Issuer And Invalid Signature Is Rejected With 401" [implements: oauth-authentication/oauth-verifier-claims-bearers-by-iss-match, meta/tests] — verify: `pytest -q tests/auth/test_oauth_jwt_verifier.py::test_bearer_with_oauth_issuer_and_invalid_signature_is_rejected_with_401` green
+
+- [ ] 2.3 Test "Bearer With Service Account Issuer Is Deferred": assert `None` returned, no exception, no log line [implements: oauth-authentication/oauth-verifier-claims-bearers-by-iss-match, meta/tests] — verify: `pytest -q tests/auth/test_oauth_jwt_verifier.py::test_bearer_with_service_account_issuer_is_deferred` green
+
+- [ ] 2.4 Test "Malformed Bearer Is Deferred": assert `None` returned, no exception [implements: oauth-authentication/oauth-verifier-claims-bearers-by-iss-match, meta/tests] — verify: `pytest -q tests/auth/test_oauth_jwt_verifier.py::test_malformed_bearer_is_deferred` green
+
+- [ ] 2.5 Test "Token Uses Cluster Url As Issuer": hardcoded cluster URL as `iss`, no real `HYDROLIX_URL` env state [implements: oauth-authentication/jwt-verification-rejects-mismatched-issuer, meta/tests] — verify: `pytest -q tests/auth/test_oauth_jwt_verifier.py::test_token_uses_cluster_url_as_issuer` green
+
+- [ ] 2.6 Test "Derived Issuer Differs From Hydrolix Url Conflation Rejected" [implements: oauth-authentication/jwt-verification-rejects-mismatched-issuer, meta/tests] — verify: `pytest -q tests/auth/test_oauth_jwt_verifier.py::test_derived_issuer_differs_from_hydrolix_url_conflation_rejected` green
+
+- [ ] 2.7 Test "Audience Not In Allowlist" [implements: oauth-authentication/jwt-verification-rejects-mismatched-audience, meta/tests] — verify: `pytest -q tests/auth/test_oauth_jwt_verifier.py::test_audience_not_in_allowlist` green
+
+- [ ] 2.8 Test "Second Allowlist Entry Matches" [implements: oauth-authentication/jwt-verification-rejects-mismatched-audience, meta/tests] — verify: `pytest -q tests/auth/test_oauth_jwt_verifier.py::test_second_allowlist_entry_matches` green
+
+- [ ] 2.9 Test "Missing Required Scope" [implements: oauth-authentication/required-scopes-enforced-when-configured, meta/tests] — verify: `pytest -q tests/auth/test_oauth_jwt_verifier.py::test_missing_required_scope` green
+
+- [ ] 2.10 Test "All Required Scopes Present Via Scope Claim" [implements: oauth-authentication/required-scopes-enforced-when-configured, meta/tests] — verify: `pytest -q tests/auth/test_oauth_jwt_verifier.py::test_all_required_scopes_present_via_scope_claim` green
+
+- [ ] 2.11 Test "All Required Scopes Present Via Scp Claim" [implements: oauth-authentication/required-scopes-enforced-when-configured, meta/tests] — verify: `pytest -q tests/auth/test_oauth_jwt_verifier.py::test_all_required_scopes_present_via_scp_claim` green
+
+- [ ] 2.12 Test "Well Formed Bearer Reaches The Mcp Tool Layer" [implements: oauth-authentication/valid-bearer-authenticates-the-request-end-to-end, meta/tests] — verify: `pytest -q tests/auth/test_oauth_jwt_verifier.py::test_well_formed_bearer_reaches_the_mcp_tool_layer` green
+
+## 3. Integration Verification
+
+- [ ] 3.1 Confirm the new verifier test module is importable alongside existing auth tests with no name collisions or fixture conflicts [implements: oauth-authentication/valid-bearer-authenticates-the-request-end-to-end, meta/tests] — verify: `pytest -q tests/auth/` exits 0 with no failures or errors reported


### PR DESCRIPTION
What does this PR do?
-----------------------

Builds on oauth-config-and-preflight. Part of the 5-change decomposition of OAuth bearer authentication for [HDX-11442](https://hydrolix.atlassian.net/browse/HDX-11442).

Modifies the `oauth-authentication` capability (established as New by oauth-config-and-preflight) to add:
- iss-based routing for chain composability: peeks bearer iss without verifying, claims iff iss matches resolved OAuth issuer, defers (returns None) otherwise. Mirrors turbine-api TokenValidator dispatch.
- Issuer match (non-conflation: resolved OAuth issuer SHALL NEVER equal HYDROLIX_URL).
- Audience allowlist (any-of `HYDROLIX_OAUTH_AUDIENCE`).
- Required scopes (all-of from `scope` + `scp`).
- Invalid bearer claimed by verifier raises 401 with `WWW-Authenticate: Bearer realm=…, resource_metadata=<url>`.

Does this PR meet the acceptance criteria?
--------------------------------------------

* [x] Documentation created/updated
* [ ] Tests added for this feature/bug
* [ ] Does this change request have any security impacts?

Release Notes
---------------------------------------------------

* Major changes:
    *
* Minor changes:
    *
* Bugfixes:
    *
* Issues Closed:
    *
* Security impacts identified:
    *

Testing
--------------------------------------------


[HDX-11442]: https://hydrolix.atlassian.net/browse/HDX-11442?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ