### PR TITLE
[IL][HDX-11442][Spec] OAuth log redaction

### DIFF
--- a/openspec/changes/oauth-log-redaction/.openspec.yaml
+++ b/openspec/changes/oauth-log-redaction/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: interactive-spec-led
+created: 2026-05-27

--- a/openspec/changes/oauth-log-redaction/design.md
+++ b/openspec/changes/oauth-log-redaction/design.md
@@ -1,0 +1,53 @@
+*Log-line shape is a tested contract: `caplog` assertions across 6 call paths enforce it on every PR.*
+
+## Context
+
+- The MCP auth layer spans four files: `mcp_hydrolix/auth/oauth.py`, `mcp_hydrolix/auth/mcp_providers.py`, `mcp_hydrolix/mcp_server.py`, `mcp_hydrolix/webapp.py`.
+- Any single JWT segment (`header`, `payload`, or `signature`) is sufficient to reassemble a usable token if logged.
+- JWT-parsing libraries frequently include the raw input in exception messages; a naive `logger.exception(exc)` is therefore a redaction failure point.
+- `caplog` captures both `record.getMessage()` and `record.args`, covering every path a value can take before reaching a log sink.
+- This change is orthogonal to all other oauth changes; it can be reviewed and merged independently.
+
+## Goals / Non-Goals
+
+**Goals:** Every `logger.*` call in the auth layer is audited and hardened so no prohibited content reaches a log record; the guarantee is CI-enforced, not a code-review convention.
+
+**Non-Goals:** Changing log verbosity; auditing non-auth modules; structured logging or log-sink configuration.
+
+## Decisions
+
+### Decision: log-content-is-tested-invariant
+
+- **Choice:** Log content for the auth layer is a tested invariant backed by `caplog` assertions, not a code-review convention.
+- **Why:** A code-review convention degrades under time pressure; a `caplog` test that runs on every PR fails loudly if any new log call introduces prohibited content, making the constraint self-enforcing.
+- **Alternatives:**
+  - Lint rule / AST check — detects static patterns only; misses dynamic cases where a token value flows into a log call via an intermediate variable.
+  - Code-review checklist — no CI enforcement; degrades under time pressure.
+- **Binding:** All `logger.*` calls added or modified in the auth layer MUST be covered by the `caplog` test suite in `tests/auth/test_log_redaction.py`. Any new `logger.exception(exc)` call in the auth layer MUST log only `type(exc).__name__`, not `str(exc)`, when the exception could quote raw token bytes.
+
+### Decision: exception-class-name-only
+
+- **Choice:** When an exception message could contain raw token bytes, the auth layer logs `type(exc).__name__` only.
+- **Why:** JWT parser libraries (e.g. `python-jose`, `PyJWT`) include the malformed input in their exception messages on parse errors. Logging the full exception message would therefore be a redaction failure for invalid-token paths. Logging just the class name preserves enough diagnostic information (the failure category) without exposing credential material.
+- **Alternatives:**
+  - Sanitize the exception message with a regex — fragile and hard to maintain as library error-message formats change.
+  - Suppress logging on error paths — removes operational visibility.
+- **Binding:** On the invalid-bearer-rejected and discovery-failure call paths, the auth layer MUST log `type(exc).__name__` (or an equivalent that does not include `str(exc)`) rather than the full exception representation.
+
+### Decision: caplog-checks-args-and-message
+
+- **Choice:** `caplog` assertions check both `record.getMessage()` and each element of `record.args`, not only the final formatted string.
+- **Why:** Python logging stores the format string and arguments separately; a prohibited value can appear in `record.args` even if `record.getMessage()` does not surface it. Checking both closes this gap.
+- **Alternatives:**
+  - Check only `record.getMessage()` — misses raw arguments that are not interpolated.
+  - Serialize the entire record to a string and scan — equivalent but less targeted.
+- **Binding:** The `caplog` test helpers in `tests/auth/test_log_redaction.py` MUST scan both `record.getMessage()` and `record.args` (flattened) for each prohibited content category.
+
+## Risks / Trade-offs
+
+- `[Risk] Tests are brittle with overly broad patterns` → Mitigation: checks key on specific token components (signature segment, base64url pattern of known length); test tokens are minted with distinct values to surface false positives.
+- `[Risk] A new auth-layer file escapes coverage` → Mitigation: the four-file scope is explicit in the spec; a fifth file without a corresponding test expansion has no `caplog` coverage — a visible code-review signal.
+
+## Open Questions
+
+*none*

--- a/openspec/changes/oauth-log-redaction/explore.md
+++ b/openspec/changes/oauth-log-redaction/explore.md
@@ -1,0 +1,10 @@
+*This change was formed before openspec introduced `explore.md` as a required artifact. No genuine pre-spec audit trail exists; the substantive design choices are recorded in `design.md`. The Q&A below disambiguates one point that an independent reviewer might otherwise misread.*
+
+## Decisions
+
+### Decision: redaction-is-cross-cutting-not-embedded
+
+- **Question**: Why is log redaction a single cross-cutting change rather than embedded in each of the other changes that emit logs in the auth layer?
+- **Answer**: The redaction invariant must hold across **every** `logger.*` call in the auth layer, regardless of which change introduced the call. A single change with a single test module that exercises all six call paths (successful activation, discovery failure, valid bearer accepted, invalid bearer rejected, SA path with no bearer, `OAuthConfigError` raised) keeps the invariant testable as a unit and easy to extend when future auth-layer changes introduce new log emitters. Embedding it would scatter the invariant across four+ test files and risk drift — a `logger.exception(exc)` added in one change could leak a token via the exception message without anyone noticing if the redaction check lived only in the OTHER change's tests.
+- **Rationale**: A cross-cutting safety property is easier to maintain as a single audit than as policy embedded in every code site that could violate it.
+- **Affects**: The orthogonal position of this change in the dependency graph; tests live in `tests/auth/test_log_redaction.py` and are not duplicated in other auth tests.

--- a/openspec/changes/oauth-log-redaction/proposal.md
+++ b/openspec/changes/oauth-log-redaction/proposal.md
@@ -1,0 +1,41 @@
+*Audit every `logger.*` call site in the MCP auth layer to guarantee no JWT credential material ever appears in log output.*
+
+## Why
+
+Log aggregation pipelines in Kubernetes clusters are not secret stores. Any raw JWT, bearer string, or JWKS private exponent that reaches a log line is permanently exposed to anyone with log-read access — a replay or forgery risk that cannot be patched after the fact. This audit closes that gap before OAuth reaches production.
+
+## Family Context / Forward References
+
+One of 5 changes decomposing OAuth bearer authentication for [HDX-11442](https://hydrolix.atlassian.net/browse/HDX-11442). All five target the shared capability `oauth-authentication`. This change is **orthogonal** — it does not depend on the other four, and they do not depend on it.
+
+- `oauth-config-and-preflight` — env-var activation gate, canonical IdP derivation, JWKS preflight.
+- `oauth-resource-metadata` — RFC 9728 protected-resource-metadata endpoint.
+- `oauth-jwt-verifier` — JWT claim validation with iss-based routing.
+- `oauth-auth-chain-and-activation` — flat auth chain composition and per-worker activation.
+- `oauth-log-redaction` (this change) — log-redaction invariant across the auth layer.
+
+## What Changes
+
+- Extend the `oauth-authentication` capability with log-redaction requirements specifying what the auth layer MAY and SHALL NOT log for three call paths: successful activation, valid bearer accepted, and invalid bearer rejected.
+- The log-redaction guarantee is a CI-enforced invariant covering 6 call paths, not a code-review convention.
+- Auth-layer error paths that could expose raw token bytes emit only the exception class name.
+
+## Capabilities
+
+### New
+
+*none*
+
+### Modified
+
+- `oauth-authentication` — adds the log-redaction invariant: no JWT credential material may appear in any auth-layer log record
+
+## Impact
+
+- `mcp_hydrolix/auth/oauth.py` — audit `logger.*` calls; replace any that could emit raw JWT bytes.
+- `mcp_hydrolix/auth/mcp_providers.py` — audit `logger.*` calls in the provider composition layer.
+- `mcp_hydrolix/mcp_server.py` — audit any auth-adjacent log calls.
+- `mcp_hydrolix/webapp.py` — audit activation-path log calls in `_activate_oauth_if_configured`.
+- `tests/auth/test_log_redaction.py` — new test module; `caplog` assertions across 6 call paths.
+- No new dependencies; no behavior change beyond log-line shape.
+- Orthogonal to all other oauth changes: this is a cross-cutting audit on `logger.*` call sites with no dependency on config gating, JWT verification logic, resource metadata, or auth-chain composition order.

--- a/openspec/changes/oauth-log-redaction/specs/oauth-authentication/spec.md
+++ b/openspec/changes/oauth-log-redaction/specs/oauth-authentication/spec.md
@@ -1,0 +1,73 @@
+*Defines what the MCP auth layer MAY and SHALL NOT include in log output to prevent JWT credential leakage.*
+
+## ADDED Requirements
+
+### Requirement: No JWT Credential Material In Logs
+
+No `logger.*` call in the MCP auth layer (`mcp_hydrolix/auth/oauth.py`, `mcp_hydrolix/auth/mcp_providers.py`, `mcp_hydrolix/mcp_server.py`, `mcp_hydrolix/webapp.py`) SHALL emit any of the following:
+
+- The raw JWT in its concatenated `header.payload.signature` form.
+- The JWT signature segment, whether standalone or embedded in any larger value.
+- The base64url-encoded header or payload segments.
+- The full `Authorization` header value.
+- JWKS private exponents or any other private key material.
+
+Decoded claim values (`sub`, `aud`, `iss`, `iat`, `exp`, `jti`, `scope`, `client_id`, and custom claims) MAY be logged — decoded claims are not credentials and cannot be used to forge a JWT without the IdP's signing key. Operator-configured values (resolved issuer URL, audience allowlist, required scopes) MAY also be logged.
+
+When an exception message could include raw token bytes (e.g. a JWT parser error that quotes the malformed input), the auth layer SHALL log only the exception class name. The full exception message MUST NOT be included in the log record for those paths.
+
+#### Scenario: Successful Activation Log Content
+
+- **WHEN** `HYDROLIX_OAUTH_AUDIENCE="mcp-test"` and `HYDROLIX_OAUTH_ISSUER="https://idp.example.com/realms/test"` are set AND OIDC discovery and JWKS preflight are mocked to return valid responses
+- **THEN** the INFO activation log line MAY include the resolved issuer URL, the audience allowlist, and the required scopes
+- **AND** SHALL NOT include the raw JWKS response body
+- **AND** SHALL NOT include any private key material
+- **AND** SHALL NOT include the raw OIDC discovery response body
+
+#### Scenario: Valid Bearer Accepted Log Content
+
+- **WHEN** `HYDROLIX_OAUTH_AUDIENCE="mcp-test"` and `HYDROLIX_OAUTH_ISSUER="https://idp.example.com/realms/test"` are set, OAuth is active, AND a request presents a JWT with `iss="https://idp.example.com/realms/test"`, `aud="mcp-test"`, `exp` in future, and valid signature against the mock JWKS
+- **THEN** any log line emitted by the auth layer MAY include decoded claim values (`sub`, `aud`, `iss`, `client_id`, etc.)
+- **AND** SHALL NOT include the raw `Authorization` header value
+- **AND** SHALL NOT include the JWT's signature segment
+- **AND** SHALL NOT include the base64url-encoded header or payload segments
+
+#### Scenario: Invalid Bearer Rejected Log Content
+
+- **WHEN** OAuth is active and a request presents an invalid bearer token that fails verification
+- **THEN** any log line emitted by the auth layer for the rejection SHALL NOT include the raw token
+- **AND** SHALL NOT include the JWT's signature segment
+- **AND** SHALL NOT include the base64url-encoded header or payload segments
+- **AND** the log line MAY include the exception class name
+- **AND** the log line MAY include any decoded claim values the verifier successfully parsed before the point of rejection
+
+### Requirement: Log Redaction Invariant Is Tested
+
+The log-redaction guarantee SHALL be backed by a `caplog`-based test module (`tests/auth/test_log_redaction.py`) that runs the full request path and asserts that no log record's `message` or `args` contains any prohibited content. The test module SHALL cover all 6 of the following call paths:
+
+1. Successful activation (OIDC discovery + JWKS preflight both succeed).
+2. Discovery failure (network error at startup).
+3. Valid bearer accepted (token passes all verification checks).
+4. Invalid bearer rejected (token fails verification).
+5. SA path with no bearer (no `Authorization` header; credential chain handles the request).
+6. `OAuthConfigError` raised (partial or malformed `HYDROLIX_OAUTH_*` configuration).
+
+The test module SHALL run on every PR as part of the standard `pytest` suite. A future `logger.exception(exc)` that leaks a token via the exception message SHALL cause this test to fail loudly.
+
+#### Scenario: Discovery Failure Does Not Log Bearer
+
+- **WHEN** OIDC discovery fails at startup (network error)
+- **AND** a subsequent request arrives with any `Authorization: Bearer <jwt>` value
+- **THEN** no log record emitted during startup or request handling SHALL contain the raw JWT, its signature segment, or its base64url-encoded header/payload segments
+
+#### Scenario: Sa Path Does Not Log Bearer Absence As Token
+
+- **WHEN** a request arrives with no `Authorization` header
+- **THEN** no log record SHALL contain a bearer token or token fragment
+- **AND** the log record MAY note that no bearer was present
+
+#### Scenario: Oauth Config Error Does Not Log Partial Config Secrets
+
+- **WHEN** `OAuthConfigError` is raised during factory initialization (partial `HYDROLIX_OAUTH_*` configuration)
+- **THEN** no log record SHALL contain JWKS private exponents or any private key material
+- **AND** the error message in the log record SHALL be the `OAuthConfigError` message, not a raw token or key value

--- a/openspec/changes/oauth-log-redaction/tasks.md
+++ b/openspec/changes/oauth-log-redaction/tasks.md
@@ -1,0 +1,43 @@
+*3 phases, 18 tasks: audit call sites, add caplog test helpers and 6 path tests, wire CI.*
+
+## 1. Audit And Harden Auth Layer Log Calls
+
+- [ ] 1.1a Audit `oauth.py` log calls: list every `logger.*` call on invalid-bearer and discovery-failure paths [implements: oauth-authentication/no-jwt-credential-material-in-logs, design/exception-class-name-only] — verify: `grep -n "logger\." mcp_hydrolix/auth/oauth.py` output reviewed and annotated for each call site
+
+- [ ] 1.1b Replace identified calls in `oauth.py` with `logger.error(type(exc).__name__)` where they were logging `str(exc)` on token-handling paths [implements: oauth-authentication/no-jwt-credential-material-in-logs, design/exception-class-name-only] — verify: `grep -n "str(exc)" mcp_hydrolix/auth/oauth.py` shows zero matches on token-handling paths
+
+- [ ] 1.2a Audit `mcp_providers.py` log calls: list every `logger.*` call that touches auth state or bearer context in the provider composition layer [implements: oauth-authentication/no-jwt-credential-material-in-logs, design/log-content-is-tested-invariant] — verify: `grep -n "logger\." mcp_hydrolix/auth/mcp_providers.py` output reviewed for any bearer or header-value references
+
+- [ ] 1.2b Replace any `mcp_providers.py` log calls that emit `Authorization` header values or bearer strings with a redacted equivalent [implements: oauth-authentication/no-jwt-credential-material-in-logs, design/log-content-is-tested-invariant] — verify: `grep -n "logger\." mcp_hydrolix/auth/mcp_providers.py` shows no bearer or header-value references in log calls
+
+- [ ] 1.3a Audit `mcp_server.py` log calls: list every `logger.*` call adjacent to auth logic that could emit JWT segments or the `Authorization` header value [implements: oauth-authentication/no-jwt-credential-material-in-logs, design/log-content-is-tested-invariant] — verify: `grep -n "logger\." mcp_hydrolix/mcp_server.py` output reviewed and annotated for auth-adjacent paths
+
+- [ ] 1.3b Replace any `mcp_server.py` auth-adjacent log calls that emit raw JWT segments or the `Authorization` header value with redacted equivalents [implements: oauth-authentication/no-jwt-credential-material-in-logs, design/log-content-is-tested-invariant] — verify: `grep -n "logger\." mcp_hydrolix/mcp_server.py` shows no bearer token references in auth-adjacent paths
+
+- [ ] 1.4a Audit `webapp.py` log calls: list every `logger.*` call in `_activate_oauth_if_configured` and confirm what each call currently emits [implements: oauth-authentication/no-jwt-credential-material-in-logs, design/log-content-is-tested-invariant] — verify: `grep -n "logger\." mcp_hydrolix/webapp.py` output reviewed and annotated for raw discovery/JWKS body references
+
+- [ ] 1.4b Confirm `webapp.py` logs only the resolved issuer URL, audience, and required scopes — remove or redact any log call that emits raw JWKS or discovery response bodies [implements: oauth-authentication/no-jwt-credential-material-in-logs, design/log-content-is-tested-invariant] — verify: `grep -n "logger\." mcp_hydrolix/webapp.py` shows no raw discovery/JWKS body references
+
+## 2. Implement Caplog Test Module
+
+- [ ] 2.1 Create `tests/auth/test_log_redaction.py`; add `_assert_no_credential_leak(records)` helper that scans both `record.getMessage()` and `record.args` (flattened) for: raw JWT pattern (`\w+\.\w+\.\w+`), base64url segments of JWT length, and the literal `Authorization` header value [implements: oauth-authentication/log-redaction-invariant-is-tested, design/caplog-checks-args-and-message] — verify: `pytest -q tests/auth/test_log_redaction.py` import succeeds with no collection errors
+
+- [ ] 2.2 Add test for scenario "Successful Activation Log Content": mock OIDC discovery + JWKS preflight to succeed; run activation under `caplog`; assert prohibited content absent [implements: oauth-authentication/no-jwt-credential-material-in-logs, meta/tests] — verify: `pytest -q tests/auth/test_log_redaction.py::test_successful_activation_log_content` green
+
+- [ ] 2.3 Add test for scenario "Valid Bearer Accepted Log Content": activate OAuth with mock JWKS; present a well-formed signed JWT; assert no log record contains the raw token, signature segment, or encoded header/payload [implements: oauth-authentication/no-jwt-credential-material-in-logs, meta/tests] — verify: `pytest -q tests/auth/test_log_redaction.py::test_valid_bearer_accepted_log_content` green
+
+- [ ] 2.4 Add test for scenario "Invalid Bearer Rejected Log Content": activate OAuth with mock JWKS; present an invalid JWT; assert no log record contains the raw token, signature segment, or encoded segments [implements: oauth-authentication/no-jwt-credential-material-in-logs, meta/tests] — verify: `pytest -q tests/auth/test_log_redaction.py::test_invalid_bearer_rejected_log_content` green
+
+- [ ] 2.5 Add test for scenario "Discovery Failure Does Not Log Bearer": simulate network failure during OIDC discovery; then present a request with a bearer token; assert no log record for either phase contains the raw JWT or its segments [implements: oauth-authentication/log-redaction-invariant-is-tested, meta/tests] — verify: `pytest -q tests/auth/test_log_redaction.py::test_discovery_failure_does_not_log_bearer` green
+
+- [ ] 2.6 Add test for scenario "Sa Path Does Not Log Bearer Absence As Token": present a request with no `Authorization` header via the SA path; assert no log record contains a bearer token fragment [implements: oauth-authentication/log-redaction-invariant-is-tested, meta/tests] — verify: `pytest -q tests/auth/test_log_redaction.py::test_sa_path_does_not_log_bearer_absence_as_token` green
+
+- [ ] 2.7 Add test for scenario "Oauth Config Error Does Not Log Partial Config Secrets": trigger `OAuthConfigError` via partial `HYDROLIX_OAUTH_*` env; assert no log record contains JWKS private exponents or private key material [implements: oauth-authentication/log-redaction-invariant-is-tested, meta/tests] — verify: `pytest -q tests/auth/test_log_redaction.py::test_oauth_config_error_does_not_log_partial_config_secrets` green
+
+## 3. Ci And Documentation
+
+- [ ] 3.1 Confirm `tests/auth/test_log_redaction.py` is collected by the default `pytest` invocation with no extra flags; add to `pyproject.toml` test paths if the auth directory is not already included [implements: oauth-authentication/log-redaction-invariant-is-tested, meta/tooling] — verify: `uv run pytest tests/auth/test_log_redaction.py` exits 0 from a clean checkout
+
+- [ ] 3.2 Add a comment block above each modified `logger.*` call in the auth layer explaining why the call is redacted (exception class name only, no header value, etc.) for future-maintainer awareness [implements: design/exception-class-name-only, meta/docs] — verify: `grep -n "redact\|credential\|token" mcp_hydrolix/auth/oauth.py mcp_hydrolix/auth/mcp_providers.py` surfaces at least one explanatory comment per modified call site
+
+- [ ] 3.3 Update `docs/oauth.md` security checklist to mark "No JWT bytes in logs" as signed off, citing `tests/auth/test_log_redaction.py` as the enforcement mechanism [implements: oauth-authentication/log-redaction-invariant-is-tested, meta/docs] — verify: `grep -n "test_log_redaction" docs/oauth.md` returns at least one match


### PR DESCRIPTION
What does this PR do?
-----------------------

Orthogonal change in the 5-part decomposition for [HDX-11442](https://hydrolix.atlassian.net/browse/HDX-11442); does not depend on the other four for spec content.

Modifies the `oauth-authentication` capability to add:
- A log-redaction invariant for the MCP auth layer (`mcp_hydrolix/auth/oauth.py`, `mcp_hydrolix/auth/mcp_providers.py`, `mcp_hydrolix/mcp_server.py`, `mcp_hydrolix/webapp.py`): no `logger.*` call may emit the raw JWT, signature segment, base64url-encoded header/payload segments, full `Authorization` header value, or JWKS private exponents. Decoded claim values (sub/aud/iss/scope/etc.) and operator-configured values MAY be logged.
- Exception-class-name-only logging on token-handling paths — `logger.error(type(exc).__name__)` rather than `str(exc)` for JWT parser exceptions whose messages can quote the malformed input.
- A `caplog`-backed test module (`tests/auth/test_log_redaction.py`) covering 6 call paths (successful activation, discovery failure, valid/invalid bearer, SA-only no-bearer, `OAuthConfigError`) so the redaction guarantee is CI-enforced, not a code-review convention.

Stacked on auth-chain-and-activation (#115) rather than `main` so spec references to `_activate_oauth_if_configured` and `mcp_providers.py` resolve against the prior in-flight change; the spec content itself is independent of the other four and could be re-targeted at `main` once #115 merges.

Does this PR meet the acceptance criteria?
--------------------------------------------

* [x] Documentation created/updated
* [ ] Tests added for this feature/bug
* [ ] Does this change request have any security impacts?

Release Notes
---------------------------------------------------

* Major changes:
    *
* Minor changes:
    *
* Bugfixes:
    *
* Issues Closed:
    *
* Security impacts identified:
    *

Testing
--------------------------------------------


[HDX-11442]: https://hydrolix.atlassian.net/browse/HDX-11442