### PR TITLE
[IL][HDX-11673] Expose execute_query SETTINGS as env vars

### DIFF
--- a/mcp_hydrolix/mcp_env.py
+++ b/mcp_hydrolix/mcp_env.py
@@ -174,15 +174,15 @@ class HydrolixConfig:
         HYDROLIX_MCP_REQUEST_TIMEOUT 120
         HYDROLIX_MCP_WORKERS 1
         HYDROLIX_MCP_WORKER_CONNECTIONS 200
-        HYDROLIX_MCP_MAX_REQUESTS 10000
+        HYDROLIX_MCP_MAX_REQUESTS 10_000
         HYDROLIX_MCP_MAX_REQUESTS_JITTER 1000
         HYDROLIX_MCP_MAX_KEEPALIVE 10
         HYDROLIX_MAX_RESULT_CELLS: Maximum number of cells (rows × columns) to return in a
-            query result before truncating (default: 50000)
+            query result before truncating (default: 50_000)
         HYDROLIX_MAX_RESULT_CELLS_LIMIT: Hard upper bound on max_cells that callers may request.
             0 means no limit is enforced (default: 0). Set this in multi-tenant HTTP/SSE
             deployments to prevent a single session from materialising very large result sets.
-        HYDROLIX_MAX_RAW_TIMERANGE: Max timerange in seconds for non-summary queries (default: 21600 = 6 hours)
+        HYDROLIX_MAX_RAW_TIMERANGE: Max timerange in seconds for non-summary queries (default: 6 hours)
     """
 
     def __init__(self) -> None:
@@ -346,7 +346,7 @@ class HydrolixConfig:
 
         Default: 30
         """
-        return int(os.getenv("HYDROLIX_CONNECT_TIMEOUT", "30"))
+        return int(os.getenv("HYDROLIX_CONNECT_TIMEOUT", 30))
 
     @property
     def send_receive_timeout(self) -> int:
@@ -354,7 +354,7 @@ class HydrolixConfig:
 
         Default: 300 (Hydrolix default)
         """
-        return int(os.getenv("HYDROLIX_SEND_RECEIVE_TIMEOUT", "300"))
+        return int(os.getenv("HYDROLIX_SEND_RECEIVE_TIMEOUT", 300))
 
     @property
     def query_pool_size(self) -> int:
@@ -373,12 +373,49 @@ class HydrolixConfig:
         return int(os.getenv("HYDROLIX_QUERY_TIMEOUT_SECS", 30))
 
     @property
+    def query_timerange_required(self) -> bool:
+        """Whether SELECT queries must constrain their primary timestamp range.
+
+        Maps to the ``hdx_query_timerange_required`` Hydrolix query setting.
+        Default: True (queries without a timerange filter are rejected). Only an
+        explicit "false" disables it, so a typo'd value keeps the guard on.
+        """
+        return os.getenv("HYDROLIX_QUERY_TIMERANGE_REQUIRED", "true").lower() != "false"
+
+    @property
+    def query_max_memory_usage(self) -> int:
+        """Max bytes of memory a single query may use.
+
+        Maps to the ``hdx_query_max_memory_usage`` Hydrolix query setting.
+        Default: 2 GiB.
+        """
+        return int(os.getenv("HYDROLIX_QUERY_MAX_MEMORY_USAGE", 2 * 1024 * 1024 * 1024))
+
+    @property
+    def query_max_attempts(self) -> int:
+        """Max number of times Hydrolix retries a query.
+
+        Maps to the ``hdx_query_max_attempts`` Hydrolix query setting.
+        Default: 1 (no retries).
+        """
+        return int(os.getenv("HYDROLIX_QUERY_MAX_ATTEMPTS", 1))
+
+    @property
+    def query_max_result_rows(self) -> int:
+        """Max number of rows a query may return.
+
+        Maps to the ``hdx_query_max_result_rows`` Hydrolix query setting.
+        Default: 100_000.
+        """
+        return int(os.getenv("HYDROLIX_QUERY_MAX_RESULT_ROWS", 100_000))
+
+    @property
     def max_result_cells(self) -> int:
         """Get the default cell budget (rows × columns) for query result truncation.
 
-        Configured via HYDROLIX_MAX_RESULT_CELLS (default: 50000).
+        Configured via HYDROLIX_MAX_RESULT_CELLS (default: 50_000).
         """
-        return int(os.getenv("HYDROLIX_MAX_RESULT_CELLS", "50000"))
+        return int(os.getenv("HYDROLIX_MAX_RESULT_CELLS", 50_000))
 
     @property
     def max_result_cells_limit(self) -> int:
@@ -390,7 +427,7 @@ class HydrolixConfig:
         Configured via HYDROLIX_MAX_RESULT_CELLS_LIMIT (default: 0, no cap enforced).
         Set to a positive integer to enforce a cap in multi-tenant HTTP/SSE deployments.
         """
-        return int(os.getenv("HYDROLIX_MAX_RESULT_CELLS_LIMIT", "0"))
+        return int(os.getenv("HYDROLIX_MAX_RESULT_CELLS_LIMIT", 0))
 
     @property
     def mcp_server_transport(self) -> str:
@@ -423,7 +460,7 @@ class HydrolixConfig:
         Only used when transport is "http" or "sse".
         Default: 8000
         """
-        return int(os.getenv("HYDROLIX_MCP_BIND_PORT", "8000"))
+        return int(os.getenv("HYDROLIX_MCP_BIND_PORT", 8000))
 
     @property
     def mcp_timeout(self) -> int:
@@ -456,9 +493,9 @@ class HydrolixConfig:
     def max_raw_timerange(self) -> int:
         """Get the max timerange in seconds for non-summary queries.
 
-        Default: 21600 (6 hours)
+        Default: 6 hours.
         """
-        return int(os.getenv("HYDROLIX_MAX_RAW_TIMERANGE", "21600"))
+        return int(os.getenv("HYDROLIX_MAX_RAW_TIMERANGE", 6 * 60 * 60))
 
     @property
     def mcp_graceful_timeout(self) -> int:
@@ -480,9 +517,9 @@ class HydrolixConfig:
         to respawn the process, so ``main.py`` passes ``None`` to uvicorn in
         that case.
 
-        Set to 0 to disable. Default: 10000.
+        Set to 0 to disable. Default: 10_000.
         """
-        return int(os.getenv("HYDROLIX_MCP_MAX_REQUESTS", 10000))
+        return int(os.getenv("HYDROLIX_MCP_MAX_REQUESTS", 10_000))
 
     @property
     def mcp_max_requests_jitter(self) -> int:
@@ -608,7 +645,7 @@ class HydrolixConfig:
             except (ValueError, TypeError):
                 raise ValueError(
                     f"Invalid HYDROLIX_MAX_RESULT_CELLS={raw_cells!r}: "
-                    "must be a positive integer (e.g. 50000)."
+                    "must be a positive integer (e.g. 50_000)."
                 )
 
         # Validate HYDROLIX_MAX_RESULT_CELLS_LIMIT: must be a non-negative integer if set.
@@ -623,6 +660,23 @@ class HydrolixConfig:
                     f"Invalid HYDROLIX_MAX_RESULT_CELLS_LIMIT={raw_limit!r}: "
                     "must be a non-negative integer (0 means no cap)."
                 )
+
+        # Validate the execute_query SETTINGS overrides: each must be a positive
+        # integer if set (they map to Hydrolix per-query limits).
+        for var_name, example in (
+            ("HYDROLIX_QUERY_MAX_MEMORY_USAGE", "2_147_483_648"),
+            ("HYDROLIX_QUERY_MAX_ATTEMPTS", "1"),
+            ("HYDROLIX_QUERY_MAX_RESULT_ROWS", "100_000"),
+        ):
+            raw = os.getenv(var_name)
+            if raw is not None:
+                try:
+                    if int(raw) <= 0:
+                        raise ValueError()
+                except (ValueError, TypeError):
+                    raise ValueError(
+                        f"Invalid {var_name}={raw!r}: must be a positive integer (e.g. {example})."
+                    )
 
 
 # Global instance placeholder for the singleton pattern

--- a/mcp_hydrolix/mcp_server.py
+++ b/mcp_hydrolix/mcp_server.py
@@ -267,9 +267,9 @@ async def execute_query(
             settings: dict[str, Any] = {
                 "readonly": 1,
                 "hdx_query_max_execution_time": HYDROLIX_CONFIG.query_timeout_sec,
-                "hdx_query_max_attempts": 1,
-                "hdx_query_max_result_rows": 100_000,
-                "hdx_query_max_memory_usage": 2 * 1024 * 1024 * 1024,  # 2GiB
+                "hdx_query_max_attempts": HYDROLIX_CONFIG.query_max_attempts,
+                "hdx_query_max_result_rows": HYDROLIX_CONFIG.query_max_result_rows,
+                "hdx_query_max_memory_usage": HYDROLIX_CONFIG.query_max_memory_usage,
                 "hdx_query_admin_comment": HDX_ADMIN_COMMENT,
             } | (extra_settings or {})
             res = await client.query(
@@ -816,9 +816,11 @@ async def run_select_query(
 
     logger.info(f"Executing SELECT query: {effective_query}")
     try:
-        extra_settings: dict[str, Any] = {"hdx_query_timerange_required": True}
+        extra_settings: dict[str, Any] = {
+            "hdx_query_timerange_required": HYDROLIX_CONFIG.query_timerange_required
+        }
         if not await _query_targets_summary_table(query):
-            extra_settings["hdx_query_max_timerange_sec"] = get_config().max_raw_timerange
+            extra_settings["hdx_query_max_timerange_sec"] = HYDROLIX_CONFIG.max_raw_timerange
         result = await execute_query(query=effective_query, extra_settings=extra_settings)
     except ToolError:
         raise

--- a/tests/e2e/_kube.py
+++ b/tests/e2e/_kube.py
@@ -248,6 +248,43 @@ def _patch_cr(api: client.CustomObjectsApi, ctx: KubeContext, body: dict[str, An
     )
 
 
+def read_mcp_hydrolix(api: client.CustomObjectsApi, ctx: KubeContext) -> Any:
+    """Return the whole spec.mcp_hydrolix block on the CR, or None if absent.
+
+    Captured before a test mutates a tunable so the exact original block can be
+    restored on teardown.
+    """
+    cr = read_cr(api, ctx)
+    return (cr.get("spec") or {}).get("mcp_hydrolix")
+
+
+def set_mcp_connection_tunable(
+    api: client.CustomObjectsApi, ctx: KubeContext, field: str, value: Any
+) -> None:
+    """Merge-patch a single spec.mcp_hydrolix.hydrolix_connection tunable.
+
+    On a CR with no mcp_hydrolix block this creates the nested path; pair it
+    with ``restore_mcp_hydrolix`` on teardown to put the block back exactly as it
+    was (including removing it entirely when it was originally absent).
+    """
+    _patch_cr(api, ctx, {"spec": {"mcp_hydrolix": {"hydrolix_connection": {field: value}}}})
+
+
+def restore_mcp_hydrolix(api: client.CustomObjectsApi, ctx: KubeContext, original: Any) -> None:
+    """Restore spec.mcp_hydrolix to a previously-captured value.
+
+    JSON merge-patch only deletes the keys it names and never prunes the empty
+    parent objects it leaves behind, so restoring a single leaf would leave
+    ``mcp_hydrolix.hydrolix_connection={}`` residue on a CR that originally had
+    no block. Null the whole block first (merge-patch delete), then re-apply the
+    captured original — when ``original`` is falsy this leaves the block absent,
+    matching the pre-test shape exactly.
+    """
+    _patch_cr(api, ctx, {"spec": {"mcp_hydrolix": None}})
+    if original:
+        _patch_cr(api, ctx, {"spec": {"mcp_hydrolix": original}})
+
+
 def read_deployment_generation(
     clients: KubeClients, ctx: KubeContext, deployment_name: str
 ) -> int | None:

--- a/tests/e2e/test_operator_tunables.py
+++ b/tests/e2e/test_operator_tunables.py
@@ -1,0 +1,114 @@
+"""End-to-end coverage for the HDX-11673 execute_query tunables.
+
+These exercise the full chain: an operator build that knows the new
+``mcp_hydrolix`` tunables (deployed via the operator-version override) injects an
+env var, which the server reads into its query SETTINGS.
+
+They only run when the operator-version override is engaged
+(MCP_HYDROLIX_E2E_OPERATOR_IMAGE set) — otherwise the operator reconciling the
+cluster may not understand the tunable and the CR patch would be a no-op or be
+rejected by CRD validation. Outside that flow they skip.
+
+The signal used is ``timerange_required`` against a real table with a primary
+timestamp: by default (operator emits true) a query with no timerange filter is
+rejected; after flipping the CR tunable to false and letting mcp-hydrolix
+redeploy, the same query succeeds. Testing both directions proves the value
+actually flowed operator -> env -> server. ``SELECT 1`` can't exercise this — it
+targets no table, so the timerange requirement never applies.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from fastmcp.exceptions import ToolError
+
+from tests.e2e._kube import (
+    read_deployment_generation,
+    read_mcp_hydrolix,
+    restore_mcp_hydrolix,
+    set_mcp_connection_tunable,
+    wait_for_rollout,
+)
+from tests.e2e._mcp_client import make_client, wait_for_endpoint_ready
+
+
+@pytest.mark.end_to_end
+class TestOperatorTunablesEndToEnd:
+    async def test_timerange_required_tunable_flows_through(
+        self, _e2e_env_guard, mcp_ready, bearer_token
+    ) -> None:
+        cfg = _e2e_env_guard
+        if not cfg.operator_image:
+            pytest.skip(
+                "operator-version override not engaged "
+                "(set MCP_HYDROLIX_E2E_OPERATOR_IMAGE to a build with the new tunables)"
+            )
+
+        clients = mcp_ready.clients
+        ctx = mcp_ready.ctx
+        host = mcp_ready.hydrolix_host
+        expected_full = f"{mcp_ready.expected_image}:{mcp_ready.expected_tag}"
+
+        def wait_for_redeploy(min_generation: int | None) -> None:
+            wait_for_rollout(
+                clients,
+                ctx,
+                deployment_name=cfg.deployment_name,
+                timeout=cfg.ready_timeout,
+                min_generation=min_generation,
+                expected_image=expected_full,
+            )
+            wait_for_endpoint_ready(host, bearer_token, timeout=cfg.ready_timeout)
+
+        # A real db.table with a primary timestamp, so the timerange requirement
+        # actually applies. Configurable for clusters without the sample dataset;
+        # must NOT be a system database (those aren't queryable in Hydrolix).
+        table = os.environ.get("MCP_HYDROLIX_E2E_TIMERANGE_TABLE", "sample.sample")
+        no_timerange_query = f"SELECT * FROM {table} LIMIT 1"
+
+        # Baseline: the operator defaults timerange_required to true, so a query
+        # with no timerange filter must be rejected with a timerange error before
+        # we change anything. This confirms the requirement is in force (and that
+        # the operator is emitting the env var) to begin with.
+        async with make_client(host, bearer_token) as client:
+            with pytest.raises(ToolError, match="(?i)time ?range"):
+                await client.call_tool("run_select_query", {"query": no_timerange_query})
+
+        # Capture the entire original mcp_hydrolix block so teardown restores the
+        # CR to its exact pre-test shape (removing the block when it was absent),
+        # rather than leaving empty hydrolix_connection residue behind.
+        original_block = read_mcp_hydrolix(clients.custom, ctx)
+
+        # Capture the pre-patch generation BEFORE mutating the CR so the rollout
+        # wait isn't satisfied by the current pods.
+        pre_gen = read_deployment_generation(clients, ctx, cfg.deployment_name)
+        try:
+            set_mcp_connection_tunable(clients.custom, ctx, "timerange_required", False)
+            wait_for_redeploy(pre_gen)
+
+            async with make_client(host, bearer_token) as client:
+                result = await client.call_tool("run_select_query", {"query": no_timerange_query})
+            assert not result.is_error, (
+                "with timerange_required=False a no-timerange query should succeed, "
+                f"but run_select_query reported is_error: {result!r}"
+            )
+        finally:
+            # Restore the original block exactly (no residue), then wait for the
+            # resulting redeploy to settle.
+            restore_gen = read_deployment_generation(clients, ctx, cfg.deployment_name)
+            restore_mcp_hydrolix(clients.custom, ctx, original_block)
+            try:
+                wait_for_rollout(
+                    clients,
+                    ctx,
+                    deployment_name=cfg.deployment_name,
+                    timeout=cfg.ready_timeout,
+                    min_generation=restore_gen,
+                    expected_image=expected_full,
+                )
+            except Exception:
+                # Best-effort restore; the session-scoped teardown still restores
+                # the container override and releases the lock.
+                pass

--- a/tests/test_mcp_env.py
+++ b/tests/test_mcp_env.py
@@ -81,6 +81,71 @@ class TestMaxRequestsRecycling:
         assert config.mcp_max_requests == 0
 
 
+class TestExecuteQuerySettings:
+    """The execute_query SETTINGS exposed as env vars (HDX-11673)."""
+
+    def test_timerange_required_default(self, config: HydrolixConfig) -> None:
+        assert config.query_timerange_required is True
+
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [("false", False), ("FALSE", False), ("true", True), ("True", True)],
+    )
+    def test_timerange_required_override(
+        self,
+        config: HydrolixConfig,
+        monkeypatch: pytest.MonkeyPatch,
+        raw: str,
+        expected: bool,
+    ) -> None:
+        monkeypatch.setenv("HYDROLIX_QUERY_TIMERANGE_REQUIRED", raw)
+        assert config.query_timerange_required is expected
+
+    def test_max_memory_usage_default(self, config: HydrolixConfig) -> None:
+        assert config.query_max_memory_usage == 2 * 1024 * 1024 * 1024
+
+    def test_max_memory_usage_override(
+        self, config: HydrolixConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HYDROLIX_QUERY_MAX_MEMORY_USAGE", "1073741824")
+        assert config.query_max_memory_usage == 1073741824
+
+    def test_max_attempts_default(self, config: HydrolixConfig) -> None:
+        assert config.query_max_attempts == 1
+
+    def test_max_attempts_override(
+        self, config: HydrolixConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HYDROLIX_QUERY_MAX_ATTEMPTS", "3")
+        assert config.query_max_attempts == 3
+
+    def test_max_result_rows_default(self, config: HydrolixConfig) -> None:
+        assert config.query_max_result_rows == 100000
+
+    def test_max_result_rows_override(
+        self, config: HydrolixConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HYDROLIX_QUERY_MAX_RESULT_ROWS", "250")
+        assert config.query_max_result_rows == 250
+
+    @pytest.mark.parametrize(
+        "var",
+        [
+            "HYDROLIX_QUERY_MAX_MEMORY_USAGE",
+            "HYDROLIX_QUERY_MAX_ATTEMPTS",
+            "HYDROLIX_QUERY_MAX_RESULT_ROWS",
+        ],
+    )
+    @pytest.mark.parametrize("bad", ["0", "-1", "notanint"])
+    def test_positive_int_validation_rejects_bad_values(
+        self, monkeypatch: pytest.MonkeyPatch, var: str, bad: str
+    ) -> None:
+        monkeypatch.setenv("HYDROLIX_URL", "https://example.invalid")
+        monkeypatch.setenv(var, bad)
+        with pytest.raises(ValueError, match=var):
+            HydrolixConfig()
+
+
 # A long-lived JWT (expires 2094) used to exercise ServiceAccountToken credential resolution.
 # Signature verification is disabled in ServiceAccountToken.__init__, so only the structure
 # and claims matter.

--- a/tests/test_query_settings.py
+++ b/tests/test_query_settings.py
@@ -170,6 +170,72 @@ class TestQuerySettings:
         assert "hdx_query_max_timerange_sec" not in settings
 
 
+async def _settings_from_execute_query() -> dict:
+    """Run execute_query against a mock client and return the SETTINGS dict."""
+    from mcp_hydrolix.mcp_server import execute_query
+
+    mock_client = AsyncMock()
+    mock_query_result = AsyncMock()
+    mock_query_result.column_names = ["id"]
+    mock_query_result.result_rows = [[1]]
+    mock_client.query.return_value = mock_query_result
+
+    mock_ctx = AsyncMock()
+    mock_ctx.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_ctx.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("mcp_hydrolix.mcp_server.create_hydrolix_client", return_value=mock_ctx):
+        await execute_query("SELECT 1")
+
+    mock_client.query.assert_awaited_once()
+    _, kwargs = mock_client.query.call_args
+    return kwargs["settings"]
+
+
+class TestExecuteQuerySettingsFromEnv:
+    """execute_query base SETTINGS reflect the HDX-11673 env vars."""
+
+    async def test_defaults_match_historical_literals(self):
+        """With no env overrides, defaults equal the previously-hardcoded values."""
+        settings = await _settings_from_execute_query()
+        assert settings["hdx_query_max_attempts"] == 1
+        assert settings["hdx_query_max_result_rows"] == 100_000
+        assert settings["hdx_query_max_memory_usage"] == 2 * 1024 * 1024 * 1024
+
+    async def test_overrides_flow_into_settings(self, monkeypatch):
+        monkeypatch.setenv("HYDROLIX_QUERY_MAX_ATTEMPTS", "5")
+        monkeypatch.setenv("HYDROLIX_QUERY_MAX_RESULT_ROWS", "42")
+        monkeypatch.setenv("HYDROLIX_QUERY_MAX_MEMORY_USAGE", "1073741824")
+        settings = await _settings_from_execute_query()
+        assert settings["hdx_query_max_attempts"] == 5
+        assert settings["hdx_query_max_result_rows"] == 42
+        assert settings["hdx_query_max_memory_usage"] == 1073741824
+
+
+class TestTimerangeRequiredFromEnv:
+    """run_select_query honors HYDROLIX_QUERY_TIMERANGE_REQUIRED."""
+
+    @patch(
+        "mcp_hydrolix.mcp_server._query_targets_summary_table",
+        new_callable=AsyncMock,
+        return_value=True,
+    )
+    @patch(
+        "mcp_hydrolix.mcp_server.execute_query",
+        new_callable=AsyncMock,
+        return_value=_fake_result(),
+    )
+    async def test_timerange_required_can_be_disabled(
+        self, mock_execute, mock_targets_summary, monkeypatch
+    ):
+        monkeypatch.setenv("HYDROLIX_QUERY_TIMERANGE_REQUIRED", "false")
+        await inspect.unwrap(run_select_query)(
+            "SELECT cnt_all FROM db.t WHERE ts > now() - INTERVAL 1 DAY"
+        )
+        _, kwargs = mock_execute.call_args
+        assert kwargs["extra_settings"]["hdx_query_timerange_required"] is False
+
+
 @pytest.fixture
 def reload_server_after_test():
     """Reload mcp_server after the test to restore the real HDX_ADMIN_COMMENT."""


### PR DESCRIPTION
> **Stacked on #126** (base branch `ebell/e2e-operator-version-override`). Review/merge #126 first; this PR's diff shows only the server changes on top of it.

## Summary

Four query-level settings were hardcoded in `execute_query` / `run_select_query`. This makes each configurable via a typed `HydrolixConfig` accessor, with the existing literal as its default — so behavior is unchanged unless an operator overrides it:

| Setting | Env var | Default |
| --- | --- | --- |
| `hdx_query_timerange_required` | `HYDROLIX_QUERY_TIMERANGE_REQUIRED` | `true` |
| `hdx_query_max_memory_usage` | `HYDROLIX_QUERY_MAX_MEMORY_USAGE` | 2 GiB |
| `hdx_query_max_attempts` | `HYDROLIX_QUERY_MAX_ATTEMPTS` | `1` |
| `hdx_query_max_result_rows` | `HYDROLIX_QUERY_MAX_RESULT_ROWS` | `100_000` |

## Housekeeping

- All int config accessors now pass int defaults to `os.getenv` (the `mcp_worker_connections` pattern)
- `run_select_query` now uses the `HYDROLIX_CONFIG` module global instead of re-calling `get_config()`.

## Tests

- Unit coverage for the accessors, their validation, and that the assembled query SETTINGS reflect the env vars (defaults are the previously-hardcoded values).
- New end-to-end test that, when the operator-version override (#126) is engaged, flips `timerange_required` and verifies a no-timerange query is rejected under the default (true), but succeeds after the tunable is set false.

Verified: `uv run pytest -m "not end_to_end and not integration_clickhouse"` green (329); exercised end-to-end against a live cluster with the operator override pointing at the companion HDX-11672/11673 operator build (hydrolix/turbine#1848).

🤖 Generated with [Claude Code](https://claude.com/claude-code)