### PR TITLE
[IL] Add MAINTAINERS.md; derive Release notes from tag annotation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -79,6 +79,15 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd  # v5
+        with:
+          # Check out by tag ref (not the default SHA-pinned checkout) so the
+          # annotated tag *object* lands locally. The default checkout fetches
+          # `+<sha>:refs/tags/<tag>`, leaving the ref pointing at the commit, so
+          # `git cat-file -t <tag>` reports `commit` and the --notes-from-tag
+          # guard below never fires. Passing an explicit ref drops the SHA pin,
+          # producing a by-name refspec that pulls the tag object. fetch-depth
+          # stays at the default 1 -- no full history needed.
+          ref: ${{ github.ref }}
       - uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
       - run: uv python install
       - name: Build MCPB bundle

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -92,9 +92,13 @@ jobs:
             gh release upload "$TAG" dist/*.mcpb --clobber
           else
             # The Release body comes from the annotated tag message. Fall back to
-            # auto-generated notes only when the annotation has no body, so a
-            # release is never published with completely empty notes.
-            if [[ -n "$(git tag -l --format='%(contents)' "$TAG")" ]]; then
+            # auto-generated notes when the tag is lightweight or its annotation
+            # has no body, so a release is never published with empty notes.
+            # `%(contents)` returns the *commit* message for a lightweight tag,
+            # so gate on the ref being a real tag object (cat-file -t == tag)
+            # before trusting its contents.
+            if [[ "$(git cat-file -t "$TAG")" == "tag" \
+                  && -n "$(git tag -l --format='%(contents)' "$TAG")" ]]; then
               gh release create "$TAG" dist/*.mcpb --notes-from-tag --title "$TAG"
             else
               echo "::warning::Tag $TAG has no annotation body; falling back to --generate-notes"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,7 +91,15 @@ jobs:
           if gh release view "$TAG" >/dev/null 2>&1; then
             gh release upload "$TAG" dist/*.mcpb --clobber
           else
-            gh release create "$TAG" dist/*.mcpb --generate-notes --title "$TAG"
+            # The Release body comes from the annotated tag message. Fall back to
+            # auto-generated notes only when the annotation has no body, so a
+            # release is never published with completely empty notes.
+            if [[ -n "$(git tag -l --format='%(contents)' "$TAG")" ]]; then
+              gh release create "$TAG" dist/*.mcpb --notes-from-tag --title "$TAG"
+            else
+              echo "::warning::Tag $TAG has no annotation body; falling back to --generate-notes"
+              gh release create "$TAG" dist/*.mcpb --generate-notes --title "$TAG"
+            fi
           fi
   bump-version:
     name: Bump to next patch version

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -51,16 +51,21 @@ must match the version currently on `main`.
    If it does not match, bump it on `main` first (`uv version <X.Y.Z>` followed
    by `uv lock --no-upgrade`, then commit and push).
 
-3. **Create an annotated tag** for that version and push it:
+3. **Write the release notes and put them in the annotated tag.** This is a
+   required, hand-crafted step — see [Release notes are
+   required](#release-notes-are-required) for the format. Author the curated
+   notes in the tag's annotation message (not a throwaway `-m "Release v0.3.4"`):
 
    ```bash
    git checkout main && git pull
-   git tag -a v0.3.4 -m "Release v0.3.4"
+   git tag -a v0.3.4 -F NOTES.md      # NOTES.md holds the curated changelog
    git push origin v0.3.4
    ```
 
    Use an *annotated* tag (`-a`), not a lightweight tag. The tag name must match
-   `v[0-9]+.[0-9]+.[0-9]+` exactly or the workflow will not trigger.
+   `v[0-9]+.[0-9]+.[0-9]+` exactly or the workflow will not trigger. Keep
+   `NOTES.md` around — you reuse the same text as the GitHub Release body in
+   step 4.
 
 4. **Watch the workflow.** The push fires `Publish release`, which (after
    `prove-main` passes) runs in parallel:
@@ -70,10 +75,11 @@ must match the version currently on `main`.
    - **`publish-docker`** — build and push the image to GAR as both
      `us-docker.pkg.dev/hdx-art/t/mcp-hydrolix:v0.3.4` and `:latest`.
    - **`publish-mcpb`** — build the MCPB bundle and attach it to a GitHub
-     Release for the tag. If no Release exists for the tag yet, it creates one
-     with **auto-generated notes** (`gh release create --generate-notes`). If a
-     Release already exists, it only uploads the bundle and **leaves the notes
-     untouched** — so a pre-existing empty Release stays empty.
+     Release for the tag. If no Release exists yet, it creates one with GitHub's
+     **auto-generated notes** (`gh release create --generate-notes`) — treat
+     these as a placeholder you overwrite with your curated notes (see [Release
+     notes are required](#release-notes-are-required)). If a Release already
+     exists, it only uploads the bundle and leaves the body untouched.
 
    ```bash
    gh run watch
@@ -87,49 +93,70 @@ must match the version currently on `main`.
 
 ### Release notes are required
 
-**Every release tag MUST have a populated GitHub Release with release notes.**
-This is non-negotiable: a tag with no notes (or a placeholder body such as the
-bare version string) is an incomplete release. Historically this slipped —
-`v0.3.3` carries proper "What's Changed" notes, but `v0.3.2` shipped with an
-empty body and the tags before it have no GitHub Release at all. Don't add to
-that list.
+**Every release MUST ship hand-crafted release notes.** This is the whole
+motivation for this section. The notes must be *curated by a human* — a grouped,
+readable changelog written for the reader — not an auto-generated PR-title dump
+and never empty.
 
-Notes are normally produced for you, but only under the right conditions:
+Both recent tags are **degenerate** and must not be used as templates:
 
-- **Let the workflow create the Release.** `publish-mcpb` generates notes via
-  `--generate-notes` *only when it creates the Release*. Do **not** pre-create
-  the Release or push the tag through the GitHub UI's "create release" flow with
-  an empty body — that leaves an empty Release the workflow won't backfill.
-- **Write good PR titles.** `--generate-notes` builds the changelog from the
-  titles of PRs merged since the previous tag, so the quality of the notes is
-  the quality of your PR titles. Squash-merge stray commits behind a clear PR
-  title rather than letting raw commit subjects leak in.
-- **Review and augment after the run.** Auto-generated notes are a starting
-  point, not the finished product. Once the Release exists, read it and add a
-  short human summary at the top — headline changes, any **breaking changes**,
-  and upgrade/migration steps (e.g. deprecated `HYDROLIX_*` env vars). Edit with:
+- `v0.3.2` — body is just the bare version string. Empty.
+- `v0.3.3` — GitHub's auto-generated "What's Changed" list (one line per merged
+  PR, including `Bump …` dependabot churn). This is a raw dump, not curated
+  notes.
 
-  ```bash
-  gh release view v0.3.4 --repo hydrolix/mcp-hydrolix              # inspect
-  gh release edit v0.3.4 --repo hydrolix/mcp-hydrolix --notes-file NOTES.md
-  ```
+The **required style** is the hand-written changelog used in the older tag
+annotations — see `v0.3.1`, `v0.3.0`, and `v0.2.4` (`git show v0.3.1`). It has:
 
-- **Backfill if a Release ended up empty.** If a tag landed without notes,
-  regenerate them rather than leaving it bare. `gh release edit` has no
-  `--generate-notes` flag, so generate via the API and pipe the body in:
+- A short heading line with the version.
+- Changes **grouped by category** — `Added` / `Changed` / `Removed` / `Fixed`
+  (Keep-a-Changelog style), or the equivalent `Bug fixes` / `Improvements` /
+  `Documentation` grouping in `v0.2.4`. Omit empty groups.
+- One bullet per user-visible change, written as a sentence, each citing its PR
+  (`(#88)`) and/or Jira ticket (`(HDX-11190)`).
+- **Breaking changes called out explicitly** — prefix the bullet with
+  `Breaking:` as in `v0.3.0`, and include the upgrade/migration step (e.g. a
+  removed or deprecated `HYDROLIX_*` env var).
 
-  ```bash
-  gh api repos/hydrolix/mcp-hydrolix/releases/generate-notes \
-    -f tag_name=v0.3.4 --jq .body |
-    gh release edit v0.3.4 --repo hydrolix/mcp-hydrolix --notes-file -
-  ```
+Example skeleton (`NOTES.md`):
+
+```markdown
+## v0.3.4
+
+### Added
+- New `…` capability. (#NNN, HDX-NNNNN)
+
+### Changed
+- Breaking: removed `HYDROLIX_OLD_VAR`; use `HYDROLIX_NEW_VAR` instead. (#NNN)
+
+### Fixed
+- … (#NNN)
+```
+
+Where the notes live:
+
+1. **In the annotated tag** — author them there at tag-creation time
+   (`git tag -a v0.3.4 -F NOTES.md`, step 3). The tag annotation is the
+   canonical record and the practice the older releases followed.
+2. **On the GitHub Release** — `publish-mcpb` creates the Release with GitHub's
+   `--generate-notes` (the v0.3.3-style dump), which is **not** acceptable as
+   the final body. After the run, overwrite it with your curated notes so the
+   Release matches the tag:
+
+   ```bash
+   gh release edit v0.3.4 --repo hydrolix/mcp-hydrolix --notes-file NOTES.md
+   ```
+
+Do not pre-create the GitHub Release with an empty body before the workflow runs
+(that is how `v0.3.2` ended up blank). Either let the workflow create it and then
+overwrite the body as above, or create it yourself with `--notes-file NOTES.md`.
 
 ### After the release
 
 - Confirm the new version is live on [PyPI](https://pypi.org/p/mcp-hydrolix) and
   that the [GitHub Release](https://github.com/hydrolix/mcp-hydrolix/releases)
-  exists for the tag, **has non-empty release notes**, and has the MCPB bundle
-  attached.
+  exists for the tag, carries your **curated release notes** (not the
+  auto-generated dump), and has the MCPB bundle attached.
 - Verify the install path works end to end:
 
   ```bash

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -2,21 +2,8 @@
 
 This document covers tasks that require privileges held by Hydrolix maintainers
 — running the end-to-end suite against a live cluster, and cutting a release.
-Contributors do not need anything here; see the [README](README.md) to install
-and use the server, and `tests/e2e/README.md` for the full e2e runbook.
-
-## Who can do this
-
-Releasing and running the e2e suite require operational access that is not
-available to outside contributors:
-
-- **PyPI** — release publishing uses Trusted Publishing (OIDC) from the
-  `pypi` GitHub Environment; no long-lived token is needed, but the workflow
-  and environment are scoped to this repository.
-- **Google Artifact Registry** (`us-docker.pkg.dev/hdx-art`) — Docker images are
-  pushed using the `GCP_GKE_CI_KEY` repository secret.
-- **A live Hydrolix cluster** — the e2e suite deploys the working tree to a real
-  Kubernetes cluster and needs `kubectl` access plus query credentials.
+Contributors and users do not need anything here; see the [README](README.md) to
+install and use the server.
 
 ## End-to-end tests
 
@@ -51,10 +38,8 @@ must match the version currently on `main`.
 
 ### Steps
 
-1. **Pick the commit.** The tag must point at a commit that is **on `main`** —
-   the workflow's first job (`prove-main`) fails the release if the tagged
-   commit is not reachable from `origin/main`. Make sure `main` is up to date
-   and green.
+1. **Pick the commit.** The tag must point at a commit that is **on `main`**. Make
+   sure `main` is up to date and green.
 
 2. **Confirm the version.** Check that `pyproject.toml` holds the version you
    intend to release:
@@ -85,8 +70,10 @@ must match the version currently on `main`.
    - **`publish-docker`** — build and push the image to GAR as both
      `us-docker.pkg.dev/hdx-art/t/mcp-hydrolix:v0.3.4` and `:latest`.
    - **`publish-mcpb`** — build the MCPB bundle and attach it to a GitHub
-     Release for the tag (creating the Release with generated notes if it does
-     not already exist).
+     Release for the tag. If no Release exists for the tag yet, it creates one
+     with **auto-generated notes** (`gh release create --generate-notes`). If a
+     Release already exists, it only uploads the bundle and **leaves the notes
+     untouched** — so a pre-existing empty Release stays empty.
 
    ```bash
    gh run watch
@@ -98,11 +85,51 @@ must match the version currently on `main`.
    version in `pyproject.toml` and `uv.lock`. No manual follow-up is needed for
    the version bump; just `git pull` on `main` afterward.
 
+### Release notes are required
+
+**Every release tag MUST have a populated GitHub Release with release notes.**
+This is non-negotiable: a tag with no notes (or a placeholder body such as the
+bare version string) is an incomplete release. Historically this slipped —
+`v0.3.3` carries proper "What's Changed" notes, but `v0.3.2` shipped with an
+empty body and the tags before it have no GitHub Release at all. Don't add to
+that list.
+
+Notes are normally produced for you, but only under the right conditions:
+
+- **Let the workflow create the Release.** `publish-mcpb` generates notes via
+  `--generate-notes` *only when it creates the Release*. Do **not** pre-create
+  the Release or push the tag through the GitHub UI's "create release" flow with
+  an empty body — that leaves an empty Release the workflow won't backfill.
+- **Write good PR titles.** `--generate-notes` builds the changelog from the
+  titles of PRs merged since the previous tag, so the quality of the notes is
+  the quality of your PR titles. Squash-merge stray commits behind a clear PR
+  title rather than letting raw commit subjects leak in.
+- **Review and augment after the run.** Auto-generated notes are a starting
+  point, not the finished product. Once the Release exists, read it and add a
+  short human summary at the top — headline changes, any **breaking changes**,
+  and upgrade/migration steps (e.g. deprecated `HYDROLIX_*` env vars). Edit with:
+
+  ```bash
+  gh release view v0.3.4 --repo hydrolix/mcp-hydrolix              # inspect
+  gh release edit v0.3.4 --repo hydrolix/mcp-hydrolix --notes-file NOTES.md
+  ```
+
+- **Backfill if a Release ended up empty.** If a tag landed without notes,
+  regenerate them rather than leaving it bare. `gh release edit` has no
+  `--generate-notes` flag, so generate via the API and pipe the body in:
+
+  ```bash
+  gh api repos/hydrolix/mcp-hydrolix/releases/generate-notes \
+    -f tag_name=v0.3.4 --jq .body |
+    gh release edit v0.3.4 --repo hydrolix/mcp-hydrolix --notes-file -
+  ```
+
 ### After the release
 
 - Confirm the new version is live on [PyPI](https://pypi.org/p/mcp-hydrolix) and
   that the [GitHub Release](https://github.com/hydrolix/mcp-hydrolix/releases)
-  has the MCPB bundle attached.
+  exists for the tag, **has non-empty release notes**, and has the MCPB bundle
+  attached.
 - Verify the install path works end to end:
 
   ```bash

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,134 @@
+# Maintainers' guide
+
+This document covers tasks that require privileges held by Hydrolix maintainers
+— running the end-to-end suite against a live cluster, and cutting a release.
+Contributors do not need anything here; see the [README](README.md) to install
+and use the server, and `tests/e2e/README.md` for the full e2e runbook.
+
+## Who can do this
+
+Releasing and running the e2e suite require operational access that is not
+available to outside contributors:
+
+- **PyPI** — release publishing uses Trusted Publishing (OIDC) from the
+  `pypi` GitHub Environment; no long-lived token is needed, but the workflow
+  and environment are scoped to this repository.
+- **Google Artifact Registry** (`us-docker.pkg.dev/hdx-art`) — Docker images are
+  pushed using the `GCP_GKE_CI_KEY` repository secret.
+- **A live Hydrolix cluster** — the e2e suite deploys the working tree to a real
+  Kubernetes cluster and needs `kubectl` access plus query credentials.
+
+## End-to-end tests
+
+A separate suite under `tests/e2e/` deploys the local working tree to a live
+Hydrolix Kubernetes cluster and smoke-tests the MCP tools against the running
+pod. It exercises **environmental integration** — container config, ingress
+auth, ClickHouse reachability from the pod — not deep business logic.
+
+It is excluded from default test runs and from the pre-push hook; running it
+requires explicit opt-in via the `end_to_end` pytest marker plus credentials and
+`kubectl` access to a cluster with `spec.mcp_hydrolix.enabled = true`.
+
+```bash
+cp .env.e2e.example .env.e2e
+$EDITOR .env.e2e   # HYDROLIX_USER, HYDROLIX_PASSWORD, MCP_HYDROLIX_E2E_KUBE_CONTEXT
+uv run pytest -m end_to_end tests/e2e/
+```
+
+See [`tests/e2e/README.md`](tests/e2e/README.md) for the full runbook:
+prerequisites, the default build-and-deploy flow, the
+`publish-feature.yml`-published-image alternative, the gated operator-version
+override, cleanup behavior, manual recovery, and troubleshooting.
+
+## Releasing a new version
+
+Releases are fully automated by [`.github/workflows/publish.yml`](.github/workflows/publish.yml),
+which triggers on **pushing an annotated tag** matching `vMAJOR.MINOR.PATCH`
+(e.g. `v0.3.4`). The version number lives in `pyproject.toml` and is managed
+with `uv version`. Between releases `main` already carries the next patch
+version (the previous release's `bump-version` job sets it), so the tag you push
+must match the version currently on `main`.
+
+### Steps
+
+1. **Pick the commit.** The tag must point at a commit that is **on `main`** —
+   the workflow's first job (`prove-main`) fails the release if the tagged
+   commit is not reachable from `origin/main`. Make sure `main` is up to date
+   and green.
+
+2. **Confirm the version.** Check that `pyproject.toml` holds the version you
+   intend to release:
+
+   ```bash
+   uv version --short   # e.g. 0.3.4
+   ```
+
+   If it does not match, bump it on `main` first (`uv version <X.Y.Z>` followed
+   by `uv lock --no-upgrade`, then commit and push).
+
+3. **Create an annotated tag** for that version and push it:
+
+   ```bash
+   git checkout main && git pull
+   git tag -a v0.3.4 -m "Release v0.3.4"
+   git push origin v0.3.4
+   ```
+
+   Use an *annotated* tag (`-a`), not a lightweight tag. The tag name must match
+   `v[0-9]+.[0-9]+.[0-9]+` exactly or the workflow will not trigger.
+
+4. **Watch the workflow.** The push fires `Publish release`, which (after
+   `prove-main` passes) runs in parallel:
+
+   - **`publish`** — `uv build` and upload to
+     [PyPI](https://pypi.org/p/mcp-hydrolix) via Trusted Publishing.
+   - **`publish-docker`** — build and push the image to GAR as both
+     `us-docker.pkg.dev/hdx-art/t/mcp-hydrolix:v0.3.4` and `:latest`.
+   - **`publish-mcpb`** — build the MCPB bundle and attach it to a GitHub
+     Release for the tag (creating the Release with generated notes if it does
+     not already exist).
+
+   ```bash
+   gh run watch
+   ```
+
+5. **Automatic version bump.** Once `publish`, `publish-docker`, and
+   `publish-mcpb` all succeed, the `bump-version` job commits a
+   `Prepare <next> development cycle` change to `main` that bumps the patch
+   version in `pyproject.toml` and `uv.lock`. No manual follow-up is needed for
+   the version bump; just `git pull` on `main` afterward.
+
+### After the release
+
+- Confirm the new version is live on [PyPI](https://pypi.org/p/mcp-hydrolix) and
+  that the [GitHub Release](https://github.com/hydrolix/mcp-hydrolix/releases)
+  has the MCPB bundle attached.
+- Verify the install path works end to end:
+
+  ```bash
+  uvx --python 3.13 --refresh-package mcp-hydrolix mcp-hydrolix --help
+  ```
+
+### Rolling back
+
+PyPI releases cannot be overwritten — a version number, once published, is
+permanent. If a release is broken:
+
+- **Yank** the bad version on PyPI (it stays downloadable for existing pins but
+  is hidden from new resolutions), then release a fixed `PATCH` bump.
+- For Docker, the GAR `:latest` tag follows the most recent successful release;
+  re-running a good release (or pushing a corrected tag) moves it back.
+
+## Publishing a feature-branch image (non-release)
+
+To get a Docker image for a branch without cutting a release — e.g. to run the
+e2e suite against a pre-built image — trigger
+[`publish-feature.yml`](.github/workflows/publish-feature.yml) manually:
+
+```bash
+gh workflow run publish-feature.yml --ref <your-branch>
+gh run watch
+```
+
+It pushes `us-docker.pkg.dev/hdx-art/t/mcp-hydrolix:branch-<branch>-<shortsha>`.
+This never touches PyPI, `:latest`, or the version number.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -7,25 +7,18 @@ install and use the server.
 
 ## End-to-end tests
 
-A separate suite under `tests/e2e/` deploys the local working tree to a live
-Hydrolix Kubernetes cluster and smoke-tests the MCP tools against the running
-pod. It exercises **environmental integration** — container config, ingress
-auth, ClickHouse reachability from the pod — not deep business logic.
+The suite under `tests/e2e/` deploys your local working tree to a live Hydrolix
+Kubernetes cluster and smoke-tests the MCP tools against the running pod. It
+requires `kubectl` access to a deployed cluster with
+`spec.mcp_hydrolix.enabled = true`, plus credentials for that cluster. It is
+excluded from default test runs and the pre-push hook, and opts in via the
+`end_to_end` pytest marker.
 
-It is excluded from default test runs and from the pre-push hook; running it
-requires explicit opt-in via the `end_to_end` pytest marker plus credentials and
-`kubectl` access to a cluster with `spec.mcp_hydrolix.enabled = true`.
-
-```bash
-cp .env.e2e.example .env.e2e
-$EDITOR .env.e2e   # HYDROLIX_USER, HYDROLIX_PASSWORD, MCP_HYDROLIX_E2E_KUBE_CONTEXT
-uv run pytest -m end_to_end tests/e2e/
-```
-
-See [`tests/e2e/README.md`](tests/e2e/README.md) for the full runbook:
-prerequisites, the default build-and-deploy flow, the
-`publish-feature.yml`-published-image alternative, the gated operator-version
-override, cleanup behavior, manual recovery, and troubleshooting.
+[`tests/e2e/README.md`](tests/e2e/README.md) is the full runbook — what the
+suite covers and the guards that keep it out of normal runs, prerequisites and
+one-time setup, the default build-and-deploy flow, the `publish-feature.yml`
+alternative, the gated operator-version override, cleanup, manual recovery, and
+troubleshooting.
 
 ## Releasing a new version
 
@@ -93,30 +86,17 @@ must match the version currently on `main`.
 
 ### Release notes are required
 
-**Every release MUST ship hand-crafted release notes.** This is the whole
-motivation for this section. The notes must be *curated by a human* — a grouped,
-readable changelog written for the reader — not an auto-generated PR-title dump
-and never empty.
+**Every release MUST ship release notes.** The notes must be *curated by a
+human* — a grouped, readable changelog written for the reader — not an
+auto-generated PR-title dump and never empty.
 
-Both recent tags are **degenerate** and must not be used as templates:
-
-- `v0.3.2` — body is just the bare version string. Empty.
-- `v0.3.3` — GitHub's auto-generated "What's Changed" list (one line per merged
-  PR, including `Bump …` dependabot churn). This is a raw dump, not curated
-  notes.
-
-The **required style** is the hand-written changelog used in the older tag
-annotations — see `v0.3.1`, `v0.3.0`, and `v0.2.4` (`git show v0.3.1`). It has:
-
-- A short heading line with the version.
-- Changes **grouped by category** — `Added` / `Changed` / `Removed` / `Fixed`
-  (Keep-a-Changelog style), or the equivalent `Bug fixes` / `Improvements` /
-  `Documentation` grouping in `v0.2.4`. Omit empty groups.
-- One bullet per user-visible change, written as a sentence, each citing its PR
-  (`(#88)`) and/or Jira ticket (`(HDX-11190)`).
-- **Breaking changes called out explicitly** — prefix the bullet with
-  `Breaking:` as in `v0.3.0`, and include the upgrade/migration step (e.g. a
-  removed or deprecated `HYDROLIX_*` env var).
+Follow [Keep a Changelog](https://keepachangelog.com/) — changes grouped under
+`Added` / `Changed` / `Removed` / `Fixed`, one bullet per user-visible change
+written as a sentence and citing its PR (`(#88)`) and/or Jira ticket
+(`(HDX-11190)`), with breaking changes prefixed `Breaking:` and carrying their
+upgrade/migration step (e.g. a removed or deprecated `HYDROLIX_*` env var). The
+older tag annotations (`v0.3.1`, `v0.3.0`, `v0.2.4`; e.g. `git show v0.3.1`) are
+good examples to follow.
 
 Example skeleton (`NOTES.md`):
 
@@ -139,17 +119,16 @@ Where the notes live:
    (`git tag -a v0.3.4 -F NOTES.md`, step 3). The tag annotation is the
    canonical record and the practice the older releases followed.
 2. **On the GitHub Release** — `publish-mcpb` creates the Release with GitHub's
-   `--generate-notes` (the v0.3.3-style dump), which is **not** acceptable as
-   the final body. After the run, overwrite it with your curated notes so the
-   Release matches the tag:
+   `--generate-notes`, which is **not** acceptable as the final body. After the
+   run, overwrite it with your curated notes so the Release matches the tag:
 
    ```bash
    gh release edit v0.3.4 --repo hydrolix/mcp-hydrolix --notes-file NOTES.md
    ```
 
-Do not pre-create the GitHub Release with an empty body before the workflow runs
-(that is how `v0.3.2` ended up blank). Either let the workflow create it and then
-overwrite the body as above, or create it yourself with `--notes-file NOTES.md`.
+Do not pre-create the GitHub Release with an empty body before the workflow runs.
+Either let the workflow create it and then overwrite the body as above, or create
+it yourself with `--notes-file NOTES.md`.
 
 ### After the release
 
@@ -162,16 +141,6 @@ overwrite the body as above, or create it yourself with `--notes-file NOTES.md`.
   ```bash
   uvx --python 3.13 --refresh-package mcp-hydrolix mcp-hydrolix --help
   ```
-
-### Rolling back
-
-PyPI releases cannot be overwritten — a version number, once published, is
-permanent. If a release is broken:
-
-- **Yank** the bad version on PyPI (it stays downloadable for existing pins but
-  is hidden from new resolutions), then release a fixed `PATCH` bump.
-- For Docker, the GAR `:latest` tag follows the most recent successful release;
-  re-running a good release (or pushing a corrected tag) moves it back.
 
 ## Publishing a feature-branch image (non-release)
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,20 +1,20 @@
 # Maintainers' guide
 
-This document covers tasks that require privileges held by Hydrolix maintainers
-— running the end-to-end suite against a live cluster, and cutting a release.
-Contributors and users do not need anything here; see the [README](README.md) to
-install and use the server.
+This document covers tasks that require Hydrolix maintainer privileges: running
+the end-to-end suite against a live cluster, and cutting a release. Contributors
+and users do not need anything here; see the [README](README.md) to install and
+use the server.
 
 ## End-to-end tests
 
 The suite under `tests/e2e/` deploys your local working tree to a live Hydrolix
 Kubernetes cluster and smoke-tests the MCP tools against the running pod. It
 requires `kubectl` access to a deployed cluster with
-`spec.mcp_hydrolix.enabled = true`, plus credentials for that cluster. It is
-excluded from default test runs and the pre-push hook, and opts in via the
-`end_to_end` pytest marker.
+`spec.mcp_hydrolix.enabled = true`, plus credentials for that cluster. The
+`end_to_end` pytest marker keeps it out of default test runs and the pre-push
+hook; pass `-m end_to_end` to opt in.
 
-[`tests/e2e/README.md`](tests/e2e/README.md) is the full runbook — what the
+[`tests/e2e/README.md`](tests/e2e/README.md) is the full runbook: what the
 suite covers and the guards that keep it out of normal runs, prerequisites and
 one-time setup, the default build-and-deploy flow, the `publish-feature.yml`
 alternative, the gated operator-version override, cleanup, manual recovery, and
@@ -44,61 +44,59 @@ must match the version currently on `main`.
    If it does not match, bump it on `main` first (`uv version <X.Y.Z>` followed
    by `uv lock --no-upgrade`, then commit and push).
 
-3. **Write the release notes and put them in the annotated tag.** This is a
-   required, hand-crafted step — see [Release notes are
-   required](#release-notes-are-required) for the format. Author the curated
-   notes in the tag's annotation message (not a throwaway `-m "Release v0.3.4"`):
+3. **Write the release notes into the annotated tag.** The tag annotation is the
+   source of truth for the notes (see [Release notes are
+   required](#release-notes-are-required) for the format). `git tag -a` opens
+   your editor so you write them inline:
 
    ```bash
    git checkout main && git pull
-   git tag -a v0.3.4 -F NOTES.md      # NOTES.md holds the curated changelog
+   git tag -a v0.3.4        # opens $EDITOR; write the curated notes as the message
    git push origin v0.3.4
    ```
 
    Use an *annotated* tag (`-a`), not a lightweight tag. The tag name must match
-   `v[0-9]+.[0-9]+.[0-9]+` exactly or the workflow will not trigger. Keep
-   `NOTES.md` around — you reuse the same text as the GitHub Release body in
-   step 4.
+   `v[0-9]+.[0-9]+.[0-9]+` or the workflow will not trigger.
 
 4. **Watch the workflow.** The push fires `Publish release`, which (after
    `prove-main` passes) runs in parallel:
 
-   - **`publish`** — `uv build` and upload to
+   - **`publish`**: `uv build` and upload to
      [PyPI](https://pypi.org/p/mcp-hydrolix) via Trusted Publishing.
-   - **`publish-docker`** — build and push the image to GAR as both
+   - **`publish-docker`**: build and push the image to GAR as both
      `us-docker.pkg.dev/hdx-art/t/mcp-hydrolix:v0.3.4` and `:latest`.
-   - **`publish-mcpb`** — build the MCPB bundle and attach it to a GitHub
-     Release for the tag. If no Release exists yet, it creates one with GitHub's
-     **auto-generated notes** (`gh release create --generate-notes`) — treat
-     these as a placeholder you overwrite with your curated notes (see [Release
-     notes are required](#release-notes-are-required)). If a Release already
-     exists, it only uploads the bundle and leaves the body untouched.
-
-   ```bash
-   gh run watch
-   ```
+   - **`publish-mcpb`**: build the MCPB bundle and attach it to the GitHub
+     Release for the tag. If no Release exists yet, it creates one with the body
+     taken from your tag annotation (`--notes-from-tag`). If a Release already
+     exists, it uploads the bundle and leaves the body untouched.
 
 5. **Automatic version bump.** Once `publish`, `publish-docker`, and
    `publish-mcpb` all succeed, the `bump-version` job commits a
    `Prepare <next> development cycle` change to `main` that bumps the patch
-   version in `pyproject.toml` and `uv.lock`. No manual follow-up is needed for
-   the version bump; just `git pull` on `main` afterward.
+   version in `pyproject.toml` and `uv.lock`. The bump needs no manual
+   follow-up.
 
 ### Release notes are required
 
-**Every release MUST ship release notes.** The notes must be *curated by a
-human* — a grouped, readable changelog written for the reader — not an
-auto-generated PR-title dump and never empty.
+**Every release MUST ship release notes.** Curate them by hand into a grouped,
+readable changelog written for the reader, not an auto-generated PR-title dump
+or an empty body.
 
-Follow [Keep a Changelog](https://keepachangelog.com/) — changes grouped under
+> [!IMPORTANT]
+> The notes have a single source: the **annotated tag message**. Write them
+> there and the rest follows: `publish-mcpb` creates the GitHub Release with its
+> body taken from the tag annotation (`--notes-from-tag`). You do not set notes
+> anywhere else, and there is nothing to copy or re-paste after the run.
+
+Follow [Keep a Changelog](https://keepachangelog.com/): group changes under
 `Added` / `Changed` / `Removed` / `Fixed`, one bullet per user-visible change
 written as a sentence and citing its PR (`(#88)`) and/or Jira ticket
-(`(HDX-11190)`), with breaking changes prefixed `Breaking:` and carrying their
+(`(HDX-11190)`). Prefix breaking changes with `Breaking:` and include the
 upgrade/migration step (e.g. a removed or deprecated `HYDROLIX_*` env var). The
 older tag annotations (`v0.3.1`, `v0.3.0`, `v0.2.4`; e.g. `git show v0.3.1`) are
-good examples to follow.
+good examples.
 
-Example skeleton (`NOTES.md`):
+Example annotation:
 
 ```markdown
 ## v0.3.4
@@ -113,40 +111,26 @@ Example skeleton (`NOTES.md`):
 - … (#NNN)
 ```
 
-Where the notes live:
-
-1. **In the annotated tag** — author them there at tag-creation time
-   (`git tag -a v0.3.4 -F NOTES.md`, step 3). The tag annotation is the
-   canonical record and the practice the older releases followed.
-2. **On the GitHub Release** — `publish-mcpb` creates the Release with GitHub's
-   `--generate-notes`, which is **not** acceptable as the final body. After the
-   run, overwrite it with your curated notes so the Release matches the tag:
-
-   ```bash
-   gh release edit v0.3.4 --repo hydrolix/mcp-hydrolix --notes-file NOTES.md
-   ```
-
-Do not pre-create the GitHub Release with an empty body before the workflow runs.
-Either let the workflow create it and then overwrite the body as above, or create
-it yourself with `--notes-file NOTES.md`.
+> [!WARNING]
+> Do not pre-create the GitHub Release before the workflow runs. The workflow
+> only sets the body when it creates the Release, so a Release you make by hand
+> keeps whatever body you gave it. You only need to push an annotated tag with
+> curated notes; let the workflow create the Release.
 
 ### After the release
 
 - Confirm the new version is live on [PyPI](https://pypi.org/p/mcp-hydrolix) and
   that the [GitHub Release](https://github.com/hydrolix/mcp-hydrolix/releases)
-  exists for the tag, carries your **curated release notes** (not the
-  auto-generated dump), and has the MCPB bundle attached.
-- Verify the install path works end to end:
+  exists for the tag, carries your curated release notes, and has the MCPB
+  bundle attached.
+- Verify the install path works end to end: install the published version from
+  PyPI in a clean environment and confirm the server starts.
 
-  ```bash
-  uvx --python 3.13 --refresh-package mcp-hydrolix mcp-hydrolix --help
-  ```
+## Publishing a feature-branch image (for testing)
 
-## Publishing a feature-branch image (non-release)
-
-To get a Docker image for a branch without cutting a release — e.g. to run the
-e2e suite against a pre-built image — trigger
-[`publish-feature.yml`](.github/workflows/publish-feature.yml) manually:
+To get a Docker image for a branch without cutting a release (e.g. to run the
+e2e suite against a pre-built image), trigger
+[`publish-feature.yml`](.github/workflows/publish-feature.yml) by hand:
 
 ```bash
 gh workflow run publish-feature.yml --ref <your-branch>
@@ -154,4 +138,5 @@ gh run watch
 ```
 
 It pushes `us-docker.pkg.dev/hdx-art/t/mcp-hydrolix:branch-<branch>-<shortsha>`.
-This never touches PyPI, `:latest`, or the version number.
+This never touches PyPI, `:latest`, or the version number. The built image can
+be deployed to a Hydrolix cluster for manual testing.

--- a/README.md
+++ b/README.md
@@ -461,10 +461,8 @@ Though not part of the MCP specification, many MCP clients allow adding headers 
 
 Note: The bind host and port settings are only used when transport is set to "http" or "sse".
 
-## End-to-end tests
+## Maintainers
 
-A separate suite under `tests/e2e/` deploys the local working tree to a live
-Hydrolix Kubernetes cluster and smoke-tests the MCP tools against the running
-pod. It is excluded from default test runs and from the pre-push hook; running
-it requires explicit opt-in via the `end_to_end` pytest marker plus
-credentials. See [`tests/e2e/README.md`](tests/e2e/README.md) for the runbook.
+Tasks that need operational privileges — running the end-to-end suite against a
+live Hydrolix cluster, and cutting a release — are documented separately in
+[`MAINTAINERS.md`](MAINTAINERS.md).


### PR DESCRIPTION
What does this PR do?
-----------------------

Adds `MAINTAINERS.md`, a guide for the two privileged tasks contributors don't
touch: running the e2e suite against a live cluster, and cutting a release. The
e2e section cross-references `tests/e2e/README.md` instead of duplicating the
runbook; the release section documents the tag-driven `publish.yml` flow, with
Keep a Changelog formatting and GFM `IMPORTANT`/`WARNING` callouts.

Also makes release notes single-sourced: `publish.yml`'s `publish-mcpb` job now
creates the GitHub Release with `--notes-from-tag`, so the Release body is taken
from the annotated tag message. It falls back to `--generate-notes` only when
the tag annotation is empty (defense-in-depth against a blank release).

Docs + CI workflow only; no server code changes.

Does this PR meet the acceptance criteria?
--------------------------------------------

* [x] Documentation created/updated
* [x] Tests added for this feature/bug — N/A (docs + CI workflow; no application code changed)
* [x] Does this change request have any security impacts? — no

Testing
--------------------------------------------

* `publish.yml` validated as parseable YAML.
* `MAINTAINERS.md` reviewed via difit.
* The `--notes-from-tag` path will be exercised on the next release tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
