### PR TITLE
[IL][HDX-11784] Support outbound HTTP(S) proxy for the Hydrolix connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,6 +416,11 @@ If no credentials are provided via the environment or the request, the request w
   * Default: None (uses the cluster's default query pool)
   * When set, every query the server issues is routed to the named pool; the pool must already exist on the cluster
   * In platform-managed (in-cluster) deployments the cluster tunable is mapped onto this same variable; the deployment owns the environment, so its value is authoritative
+* `HYDROLIX_HTTPS_PROXY` / `HYDROLIX_HTTP_PROXY`: Outbound proxy for reaching the Hydrolix cluster
+  * Default: None (connect directly)
+  * Set one to route the connection through a corporate proxy; include the scheme, e.g. `http://proxy.corp:8080`. If both are set, `HYDROLIX_HTTPS_PROXY` wins
+  * The standard `HTTP_PROXY`/`HTTPS_PROXY` environment variables are **not** used — the server needs these explicit `HYDROLIX_`-prefixed vars
+  * This is the single egress proxy for all cluster traffic, including the internal `/version` capability probe; the proxy must permit that request, or the server silently falls back to non-parameterized queries
   * Note: this is unrelated to `HYDROLIX_QUERIES_POOL_SIZE`, which sizes the client-side query thread pool
 
 

--- a/mcp_hydrolix/mcp_env.py
+++ b/mcp_hydrolix/mcp_env.py
@@ -8,7 +8,7 @@ import logging
 import os
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Optional
+from typing import Optional, TypedDict
 from urllib.parse import ParseResult, urlparse
 
 from mcp_hydrolix.auth.credentials import HydrolixCredential, ServiceAccountToken, UsernamePassword
@@ -105,6 +105,17 @@ def _parse_hydrolix_url() -> Optional[ParseResult]:
     if not parsed.hostname:
         raise ValueError(f"Invalid HYDROLIX_URL={raw!r}: missing hostname.")
     return parsed
+
+
+class ProxyPoolKwargs(TypedDict, total=False):
+    """Outbound-proxy kwargs for ``get_pool_manager``. At most one key is set.
+
+    ``https_proxy`` wins when both env vars are present; ``get_pool_manager``
+    raises if both are passed together.
+    """
+
+    https_proxy: str
+    http_proxy: str
 
 
 class TransportType(str, Enum):
@@ -527,7 +538,7 @@ class HydrolixConfig:
         """
         return os.getenv("HYDROLIX_QUERY_POOL", "").strip() or None
 
-    def proxy_pool_kwargs(self) -> dict[str, str]:
+    def proxy_pool_kwargs(self) -> ProxyPoolKwargs:
         """Outbound-proxy kwargs for the shared urllib3 pool (``get_pool_manager``).
 
         We hand clickhouse-connect a pre-built ``pool_mgr``, so it skips its own
@@ -538,41 +549,31 @@ class HydrolixConfig:
         ``HYDROLIX_HTTP_PROXY`` -> ``{"http_proxy": ...}``, else ``{}`` (direct).
         ``https`` wins because ``get_pool_manager`` raises ``ProgrammingError``
         if both are passed. Blank/whitespace is treated as unset (MCPB hosts
-        inject empty user_config fields as empty strings).
+        inject empty user_config fields as empty strings). The value is validated
+        like ``HYDROLIX_URL`` (scheme + host required), so a scheme-less
+        ``host:port`` is rejected up front rather than silently normalized.
 
         Operational notes:
           * The value is the single egress proxy for ALL cluster traffic --
             queries *and* the ``/version`` capability probe -- regardless of
             target scheme. The proxy must permit both; if it blocks the probe,
             the server silently falls back to non-parameterized queries.
-          * Include the scheme (``http://proxy:8080``). ``get_pool_manager``
-            normalizes a bare ``host:port`` to ``https://`` for HYDROLIX_HTTPS_PROXY
-            and ``http://`` for HYDROLIX_HTTP_PROXY, which can surprise (e.g. TLS
-            attempted against a plaintext proxy port).
           * ``HYDROLIX_VERIFY=false`` also disables TLS verification on an
             ``https://`` proxy leg (clickhouse-connect uses one cert_reqs flag).
         """
         if https_proxy := os.getenv("HYDROLIX_HTTPS_PROXY", "").strip():
-            return {"https_proxy": https_proxy}
-        if http_proxy := os.getenv("HYDROLIX_HTTP_PROXY", "").strip():
-            return {"http_proxy": http_proxy}
-        return {}
+            key, var, value = "https_proxy", "HYDROLIX_HTTPS_PROXY", https_proxy
+        elif http_proxy := os.getenv("HYDROLIX_HTTP_PROXY", "").strip():
+            key, var, value = "http_proxy", "HYDROLIX_HTTP_PROXY", http_proxy
+        else:
+            return {}
 
-    def client_pool_kwargs(self) -> dict[str, Any]:
-        """Kwargs for the shared ``get_pool_manager`` call that backs every client.
-
-        Single source of truth for how the shared urllib3 pool is built, so the
-        proxy wiring (``proxy_pool_kwargs``) cannot silently drop out of the real
-        connection path without a test noticing. ``mcp_server`` builds the shared
-        pool from exactly this dict.
-        """
-        return {
-            "maxsize": self.query_pool_size,
-            "num_pools": 1,
-            "verify": self.verify,
-            # Outbound proxy when configured; empty -> plain PoolManager (direct).
-            **self.proxy_pool_kwargs(),
-        }
+        parsed = urlparse(value)
+        if parsed.scheme not in ("http", "https") or not parsed.hostname:
+            raise ValueError(
+                f"Invalid {var}={value!r}: include a scheme, e.g. http://proxy.corp:8080."
+            )
+        return {key: value}
 
     @property
     def mcp_graceful_timeout(self) -> int:

--- a/mcp_hydrolix/mcp_env.py
+++ b/mcp_hydrolix/mcp_env.py
@@ -189,6 +189,11 @@ class HydrolixConfig:
             platform-managed (in-cluster) deployments the cluster tunable is mapped onto this
             same variable; since the platform owns the process environment there, its value is
             authoritative. (default: None -- use the cluster default pool)
+        HYDROLIX_HTTPS_PROXY / HYDROLIX_HTTP_PROXY: Outbound proxy for reaching the cluster.
+            Set one (https wins if both are set) to route the connection through a corporate
+            proxy; include the scheme (e.g. http://proxy.corp:8080). This is the single egress
+            proxy for all cluster traffic. See ``proxy_pool_kwargs`` for the full contract.
+            (default: None -- connect directly)
     """
 
     def __init__(self) -> None:
@@ -521,6 +526,37 @@ class HydrolixConfig:
         empty user_config fields do not send an empty pool name.
         """
         return os.getenv("HYDROLIX_QUERY_POOL", "").strip() or None
+
+    def proxy_pool_kwargs(self) -> dict[str, str]:
+        """Outbound-proxy kwargs for the shared urllib3 pool (``get_pool_manager``).
+
+        We hand clickhouse-connect a pre-built ``pool_mgr``, so it skips its own
+        ``HTTP(S)_PROXY`` detection, and urllib3's ``PoolManager`` ignores proxy
+        env too -- this is the only place the connection learns about a proxy.
+
+        Precedence: ``HYDROLIX_HTTPS_PROXY`` -> ``{"https_proxy": ...}``, else
+        ``HYDROLIX_HTTP_PROXY`` -> ``{"http_proxy": ...}``, else ``{}`` (direct).
+        ``https`` wins because ``get_pool_manager`` raises ``ProgrammingError``
+        if both are passed. Blank/whitespace is treated as unset (MCPB hosts
+        inject empty user_config fields as empty strings).
+
+        Operational notes:
+          * The value is the single egress proxy for ALL cluster traffic --
+            queries *and* the ``/version`` capability probe -- regardless of
+            target scheme. The proxy must permit both; if it blocks the probe,
+            the server silently falls back to non-parameterized queries.
+          * Include the scheme (``http://proxy:8080``). ``get_pool_manager``
+            normalizes a bare ``host:port`` to ``https://`` for HYDROLIX_HTTPS_PROXY
+            and ``http://`` for HYDROLIX_HTTP_PROXY, which can surprise (e.g. TLS
+            attempted against a plaintext proxy port).
+          * ``HYDROLIX_VERIFY=false`` also disables TLS verification on an
+            ``https://`` proxy leg (clickhouse-connect uses one cert_reqs flag).
+        """
+        if https_proxy := os.getenv("HYDROLIX_HTTPS_PROXY", "").strip():
+            return {"https_proxy": https_proxy}
+        if http_proxy := os.getenv("HYDROLIX_HTTP_PROXY", "").strip():
+            return {"http_proxy": http_proxy}
+        return {}
 
     @property
     def mcp_graceful_timeout(self) -> int:

--- a/mcp_hydrolix/mcp_env.py
+++ b/mcp_hydrolix/mcp_env.py
@@ -8,7 +8,7 @@ import logging
 import os
 from dataclasses import dataclass
 from enum import Enum
-from typing import Optional
+from typing import Any, Optional
 from urllib.parse import ParseResult, urlparse
 
 from mcp_hydrolix.auth.credentials import HydrolixCredential, ServiceAccountToken, UsernamePassword
@@ -557,6 +557,22 @@ class HydrolixConfig:
         if http_proxy := os.getenv("HYDROLIX_HTTP_PROXY", "").strip():
             return {"http_proxy": http_proxy}
         return {}
+
+    def client_pool_kwargs(self) -> dict[str, Any]:
+        """Kwargs for the shared ``get_pool_manager`` call that backs every client.
+
+        Single source of truth for how the shared urllib3 pool is built, so the
+        proxy wiring (``proxy_pool_kwargs``) cannot silently drop out of the real
+        connection path without a test noticing. ``mcp_server`` builds the shared
+        pool from exactly this dict.
+        """
+        return {
+            "maxsize": self.query_pool_size,
+            "num_pools": 1,
+            "verify": self.verify,
+            # Outbound proxy when configured; empty -> plain PoolManager (direct).
+            **self.proxy_pool_kwargs(),
+        }
 
     @property
     def mcp_graceful_timeout(self) -> int:

--- a/mcp_hydrolix/mcp_server.py
+++ b/mcp_hydrolix/mcp_server.py
@@ -141,6 +141,9 @@ pool_kwargs: dict[str, Any] = {
     "maxsize": HYDROLIX_CONFIG.query_pool_size,
     "num_pools": 1,
     "verify": HYDROLIX_CONFIG.verify,
+    # Outbound proxy when configured; empty -> plain PoolManager (direct).
+    # See HydrolixConfig.proxy_pool_kwargs for the contract and caveats.
+    **HYDROLIX_CONFIG.proxy_pool_kwargs(),
 }
 
 if HYDROLIX_CONFIG.verify:

--- a/mcp_hydrolix/mcp_server.py
+++ b/mcp_hydrolix/mcp_server.py
@@ -137,9 +137,24 @@ async def create_hydrolix_client(pool_mgr, request_credential: Optional[Hydrolix
 common.set_setting("invalid_setting_action", "send")
 common.set_setting("autogenerate_session_id", False)
 
-# Single source of truth for the shared pool's kwargs (incl. any outbound proxy);
-# see HydrolixConfig.client_pool_kwargs / proxy_pool_kwargs for the contract.
-pool_kwargs: dict[str, Any] = HYDROLIX_CONFIG.client_pool_kwargs()
+
+def client_pool_kwargs(config: HydrolixConfig) -> dict[str, Any]:
+    """Kwargs for the shared ``get_pool_manager`` call that backs every client.
+
+    Single source of truth for how the shared urllib3 pool is built, so the proxy
+    wiring (``config.proxy_pool_kwargs``) cannot silently drop out of the real
+    connection path without a test noticing.
+    """
+    return {
+        "maxsize": config.query_pool_size,
+        "num_pools": 1,
+        "verify": config.verify,
+        # Outbound proxy when configured; empty -> plain PoolManager (direct).
+        **config.proxy_pool_kwargs(),
+    }
+
+
+pool_kwargs: dict[str, Any] = client_pool_kwargs(HYDROLIX_CONFIG)
 
 if HYDROLIX_CONFIG.verify:
     import urllib3

--- a/mcp_hydrolix/mcp_server.py
+++ b/mcp_hydrolix/mcp_server.py
@@ -137,14 +137,9 @@ async def create_hydrolix_client(pool_mgr, request_credential: Optional[Hydrolix
 common.set_setting("invalid_setting_action", "send")
 common.set_setting("autogenerate_session_id", False)
 
-pool_kwargs: dict[str, Any] = {
-    "maxsize": HYDROLIX_CONFIG.query_pool_size,
-    "num_pools": 1,
-    "verify": HYDROLIX_CONFIG.verify,
-    # Outbound proxy when configured; empty -> plain PoolManager (direct).
-    # See HydrolixConfig.proxy_pool_kwargs for the contract and caveats.
-    **HYDROLIX_CONFIG.proxy_pool_kwargs(),
-}
+# Single source of truth for the shared pool's kwargs (incl. any outbound proxy);
+# see HydrolixConfig.client_pool_kwargs / proxy_pool_kwargs for the contract.
+pool_kwargs: dict[str, Any] = HYDROLIX_CONFIG.client_pool_kwargs()
 
 if HYDROLIX_CONFIG.verify:
     import urllib3

--- a/tests/test_mcp_env.py
+++ b/tests/test_mcp_env.py
@@ -595,21 +595,36 @@ class TestProxyPoolKwargs:
         monkeypatch.setenv("HYDROLIX_HTTP_PROXY", "http://plain.corp:8080")
         assert config.proxy_pool_kwargs() == {"http_proxy": "http://plain.corp:8080"}
 
+    @pytest.mark.parametrize(
+        "bad",
+        ["proxy.corp:8080", "proxy.corp", "ftp://proxy.corp:8080", "http://"],
+        ids=["no-scheme", "host-only", "bad-scheme", "no-host"],
+    )
+    def test_malformed_proxy_url_raises(
+        self, config: HydrolixConfig, monkeypatch: pytest.MonkeyPatch, bad: str
+    ) -> None:
+        # Validated like HYDROLIX_URL: scheme (http/https) + host required.
+        monkeypatch.setenv("HYDROLIX_HTTPS_PROXY", bad)
+        with pytest.raises(ValueError, match="HYDROLIX_HTTPS_PROXY"):
+            config.proxy_pool_kwargs()
+
 
 class TestProxyPoolWiring:
     """End-to-end: the shared pool actually becomes a ProxyManager when configured.
 
-    These build the pool from ``config.client_pool_kwargs()`` -- the exact dict
-    ``mcp_server`` feeds to ``get_pool_manager`` -- so the proxy spread cannot
-    silently drop out of the real connection path without failing here. Pins the
-    contract with clickhouse-connect: ProxyManager when a proxy is set, plain
-    PoolManager when it is not.
+    These build the pool from ``mcp_server.client_pool_kwargs(config)`` -- the
+    exact dict ``mcp_server`` feeds to ``get_pool_manager`` -- so the proxy spread
+    cannot silently drop out of the real connection path without failing here.
+    Pins the contract with clickhouse-connect: ProxyManager when a proxy is set,
+    plain PoolManager when it is not.
     """
 
     def _build_pool(self, config: HydrolixConfig):
         from clickhouse_connect.driver import httputil
 
-        return httputil.get_pool_manager(**config.client_pool_kwargs())
+        from mcp_hydrolix.mcp_server import client_pool_kwargs
+
+        return httputil.get_pool_manager(**client_pool_kwargs(config))
 
     def test_no_proxy_builds_plain_pool_manager(self, config: HydrolixConfig) -> None:
         from urllib3.poolmanager import PoolManager, ProxyManager

--- a/tests/test_mcp_env.py
+++ b/tests/test_mcp_env.py
@@ -597,27 +597,19 @@ class TestProxyPoolKwargs:
 
 
 class TestProxyPoolWiring:
-    """End-to-end: the resolver output must actually build a proxied urllib3 pool.
+    """End-to-end: the shared pool actually becomes a ProxyManager when configured.
 
-    The unit tests above pin the returned dict; these pin the *contract* with
-    clickhouse-connect -- that feeding proxy_pool_kwargs() through the same
-    get_pool_manager() construction mcp_server uses yields a ProxyManager when a
-    proxy is set and a plain PoolManager when it is not. This is what actually
-    breaks proxy-only deployments if the wiring regresses.
+    These build the pool from ``config.client_pool_kwargs()`` -- the exact dict
+    ``mcp_server`` feeds to ``get_pool_manager`` -- so the proxy spread cannot
+    silently drop out of the real connection path without failing here. Pins the
+    contract with clickhouse-connect: ProxyManager when a proxy is set, plain
+    PoolManager when it is not.
     """
 
     def _build_pool(self, config: HydrolixConfig):
         from clickhouse_connect.driver import httputil
 
-        # Mirror mcp_server.py's pool_kwargs construction (minus the proxy spread,
-        # which is exactly what we're exercising here).
-        pool_kwargs = {
-            "maxsize": config.query_pool_size,
-            "num_pools": 1,
-            "verify": config.verify,
-            **config.proxy_pool_kwargs(),
-        }
-        return httputil.get_pool_manager(**pool_kwargs)
+        return httputil.get_pool_manager(**config.client_pool_kwargs())
 
     def test_no_proxy_builds_plain_pool_manager(self, config: HydrolixConfig) -> None:
         from urllib3.poolmanager import PoolManager, ProxyManager

--- a/tests/test_mcp_env.py
+++ b/tests/test_mcp_env.py
@@ -547,3 +547,99 @@ class TestConnectionTargetValidation:
         monkeypatch.setenv("HYDROLIX_MCP_SERVER_TRANSPORT", "stdio")
         monkeypatch.setenv("HYDROLIX_HOST", "myhost")
         HydrolixConfig()  # no raise
+
+
+class TestProxyPoolKwargs:
+    """``proxy_pool_kwargs()`` resolves the outbound proxy for the shared urllib3 pool.
+
+    Because mcp-hydrolix passes clickhouse-connect a pre-built ``pool_mgr``,
+    clickhouse-connect's own env-proxy detection is skipped and urllib3 does not
+    read proxy env vars. This method is the explicit, HYDROLIX-namespaced hook
+    that lets a proxy-bound deployment route the connection. It feeds a single
+    proxy into ``get_pool_manager`` (which raises ``ProgrammingError`` if both
+    ``http_proxy`` and ``https_proxy`` are passed), so at most one key is emitted.
+    """
+
+    def test_no_proxy_returns_empty(self, config: HydrolixConfig) -> None:
+        # Default: no proxy configured -> empty kwargs -> plain PoolManager (direct).
+        assert config.proxy_pool_kwargs() == {}
+
+    def test_https_proxy(self, config: HydrolixConfig, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HYDROLIX_HTTPS_PROXY", "http://proxy.corp:8080")
+        assert config.proxy_pool_kwargs() == {"https_proxy": "http://proxy.corp:8080"}
+
+    def test_http_proxy(self, config: HydrolixConfig, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HYDROLIX_HTTP_PROXY", "http://proxy.corp:8080")
+        assert config.proxy_pool_kwargs() == {"http_proxy": "http://proxy.corp:8080"}
+
+    def test_https_wins_when_both_set(
+        self, config: HydrolixConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Both set: emit only https_proxy -- never both, which would make
+        # clickhouse-connect's get_pool_manager raise ProgrammingError.
+        monkeypatch.setenv("HYDROLIX_HTTPS_PROXY", "http://secure.corp:8080")
+        monkeypatch.setenv("HYDROLIX_HTTP_PROXY", "http://plain.corp:8080")
+        assert config.proxy_pool_kwargs() == {"https_proxy": "http://secure.corp:8080"}
+
+    def test_blank_https_proxy_is_unset(
+        self, config: HydrolixConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # MCPB hosts inject empty user_config fields as blank strings.
+        monkeypatch.setenv("HYDROLIX_HTTPS_PROXY", "   ")
+        assert config.proxy_pool_kwargs() == {}
+
+    def test_blank_https_falls_through_to_http(
+        self, config: HydrolixConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("HYDROLIX_HTTPS_PROXY", "")
+        monkeypatch.setenv("HYDROLIX_HTTP_PROXY", "http://plain.corp:8080")
+        assert config.proxy_pool_kwargs() == {"http_proxy": "http://plain.corp:8080"}
+
+
+class TestProxyPoolWiring:
+    """End-to-end: the resolver output must actually build a proxied urllib3 pool.
+
+    The unit tests above pin the returned dict; these pin the *contract* with
+    clickhouse-connect -- that feeding proxy_pool_kwargs() through the same
+    get_pool_manager() construction mcp_server uses yields a ProxyManager when a
+    proxy is set and a plain PoolManager when it is not. This is what actually
+    breaks proxy-only deployments if the wiring regresses.
+    """
+
+    def _build_pool(self, config: HydrolixConfig):
+        from clickhouse_connect.driver import httputil
+
+        # Mirror mcp_server.py's pool_kwargs construction (minus the proxy spread,
+        # which is exactly what we're exercising here).
+        pool_kwargs = {
+            "maxsize": config.query_pool_size,
+            "num_pools": 1,
+            "verify": config.verify,
+            **config.proxy_pool_kwargs(),
+        }
+        return httputil.get_pool_manager(**pool_kwargs)
+
+    def test_no_proxy_builds_plain_pool_manager(self, config: HydrolixConfig) -> None:
+        from urllib3.poolmanager import PoolManager, ProxyManager
+
+        pool = self._build_pool(config)
+        assert isinstance(pool, PoolManager)
+        assert not isinstance(pool, ProxyManager)
+
+    def test_https_proxy_builds_proxy_manager(
+        self, config: HydrolixConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from urllib3.poolmanager import ProxyManager
+
+        monkeypatch.setenv("HYDROLIX_HTTPS_PROXY", "http://proxy.corp:8080")
+        pool = self._build_pool(config)
+        assert isinstance(pool, ProxyManager)
+
+    def test_http_proxy_builds_proxy_manager(
+        self, config: HydrolixConfig, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from urllib3.poolmanager import ProxyManager
+
+        monkeypatch.setenv("HYDROLIX_HTTP_PROXY", "http://proxy.corp:8080")
+        pool = self._build_pool(config)
+        assert isinstance(pool, ProxyManager)


### PR DESCRIPTION
## What / why

mcp-hydrolix hands clickhouse-connect a pre-built shared `pool_mgr`, which makes clickhouse-connect skip its own `HTTP(S)_PROXY` detection (`check_env_proxy` only runs when it builds its own pool). urllib3's `PoolManager` doesn't read proxy env vars either. Net: the server always connects **directly**, so a caller behind a mandatory corporate proxy cannot reach the cluster at all without monkeypatching internals.

Reported via a customer support case (see the linked Jira for details). The reporter worked around it by patching `clickhouse_connect.httputil.get_pool_manager` to inject the env proxy; this makes it a first-class, supported option.

## Change

- `HydrolixConfig.proxy_pool_kwargs()` reads explicit, HYDROLIX-namespaced `HYDROLIX_HTTPS_PROXY` / `HYDROLIX_HTTP_PROXY` and returns a `ProxyPoolKwargs` TypedDict:
  - `https` wins if both are set (clickhouse-connect's `get_pool_manager` raises if both are passed, so we emit at most one).
  - the value is validated like `HYDROLIX_URL` (scheme `http`/`https` + host required); a scheme-less `host:port` is rejected at startup rather than silently normalized.
  - blank/whitespace treated as unset (MCPB injects empty fields as `""`).
  - returns `{}` when unset — preserving the direct-connection default.
- `mcp_server.client_pool_kwargs(config)` composes this into the shared pool build, so it becomes a `urllib3.ProxyManager` when configured. It's the single source of truth for the pool kwargs (the wiring test asserts on it), so the proxy can't silently drop out of the connection path.
- We deliberately do **not** honor the ambient `HTTP_PROXY`/`HTTPS_PROXY`, to avoid surprising in-cluster/platform deployments and to match our all-`HYDROLIX_`-prefixed config convention.

## Example

```jsonc
"mcp-hydrolix": {
  "command": "uvx",
  "args": ["--python", "3.13", "--refresh-package", "mcp-hydrolix", "mcp-hydrolix"],
  "env": {
    "HYDROLIX_URL": "https://mycluster.trafficpeak.live",
    "HYDROLIX_TOKEN": "…",
    "HYDROLIX_HTTPS_PROXY": "http://proxy.corp:8080"
  }
}
```

## Caveats (documented in the config docstring + README)

- The value is the **single egress proxy for all cluster traffic**, including the internal `/version` capability probe. If the proxy blocks that request, the server silently falls back to non-parameterized queries.
- The scheme is **required** (`http://proxy:8080`); a scheme-less `host:port` is rejected at startup with a clear error.
- `HYDROLIX_VERIFY=false` also disables TLS verification on an `https://` proxy leg (clickhouse-connect uses a single `cert_reqs`).

## Tests

- Unit coverage for the resolver: precedence, blank handling, https-wins, and malformed-URL rejection.
- A wiring test that `client_pool_kwargs` builds a `ProxyManager` (proxy set) vs plain `PoolManager` (unset) via clickhouse-connect's `get_pool_manager`.
- Full unit suite green (live-cluster markers deselected); ruff clean.

Jira: https://hydrolix.atlassian.net/browse/HDX-11784

🤖 Generated with [Claude Code](https://claude.com/claude-code)