### PR TITLE
[IL][MCP][HDX-11831] Add HYDROLIX_HTTP_QUERY_PATH for non-root query paths (eg default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,9 +364,7 @@ When `HYDROLIX_MCP_SERVER_TRANSPORT` is `http` or `sse`, `HYDROLIX_URL` *specifi
 These override the values derived from `HYDROLIX_URL`. They are useful for in-cluster deployments where the HTTP query endpoint and the version-API live at different internal hostnames or ports. Override precedence: explicit new var > deprecated alias > `HYDROLIX_URL`-derived > hard default.
 
 * `HYDROLIX_HTTP_QUERY_HOST` / `HYDROLIX_HTTP_QUERY_PORT` / `HYDROLIX_HTTP_QUERY_SECURE`: override the ClickHouse HTTP query endpoint.
-* `HYDROLIX_HTTP_QUERY_PATH`: override the request path for the ClickHouse HTTP query endpoint.
-  * Default: `/query`. Reaching a cluster from *outside* goes through Traefik, which serves the query engine under `/query`; the default means `HYDROLIX_URL` alone works for external deployments.
-  * Set to `/` (or empty) for direct / in-cluster targets that serve queries at the root.
+* `HYDROLIX_HTTP_QUERY_PATH`: override the request path for the ClickHouse HTTP query endpoint (default `/query`, matching Traefik's external routing; set to `/` for in-cluster targets that serve queries at the root).
 * `HYDROLIX_VERSION_API_HOST` / `HYDROLIX_VERSION_API_PORT` / `HYDROLIX_VERSION_API_SECURE`: override the REST `/version` probe endpoint. `HYDROLIX_VERSION_API_SECURE` inherits from the resolved HTTP-query secure value by default.
 
 #### Deprecated variables

--- a/README.md
+++ b/README.md
@@ -364,6 +364,9 @@ When `HYDROLIX_MCP_SERVER_TRANSPORT` is `http` or `sse`, `HYDROLIX_URL` *specifi
 These override the values derived from `HYDROLIX_URL`. They are useful for in-cluster deployments where the HTTP query endpoint and the version-API live at different internal hostnames or ports. Override precedence: explicit new var > deprecated alias > `HYDROLIX_URL`-derived > hard default.
 
 * `HYDROLIX_HTTP_QUERY_HOST` / `HYDROLIX_HTTP_QUERY_PORT` / `HYDROLIX_HTTP_QUERY_SECURE`: override the ClickHouse HTTP query endpoint.
+* `HYDROLIX_HTTP_QUERY_PATH`: override the request path for the ClickHouse HTTP query endpoint.
+  * Default: `/query`. Reaching a cluster from *outside* goes through Traefik, which serves the query engine under `/query`; the default means `HYDROLIX_URL` alone works for external deployments.
+  * Set to `/` (or empty) for direct / in-cluster targets that serve queries at the root.
 * `HYDROLIX_VERSION_API_HOST` / `HYDROLIX_VERSION_API_PORT` / `HYDROLIX_VERSION_API_SECURE`: override the REST `/version` probe endpoint. `HYDROLIX_VERSION_API_SECURE` inherits from the resolved HTTP-query secure value by default.
 
 #### Deprecated variables

--- a/README.md
+++ b/README.md
@@ -378,6 +378,7 @@ The following are still honored during the transition window but will be removed
 | `HYDROLIX_SECURE` | `HYDROLIX_HTTP_QUERY_SECURE` |
 | `HYDROLIX_API_HOST` | `HYDROLIX_VERSION_API_HOST` |
 | `HYDROLIX_API_PORT` | `HYDROLIX_VERSION_API_PORT` |
+| `HYDROLIX_PROXY_PATH` | `HYDROLIX_HTTP_QUERY_PATH` |
 
 External operators using any of these will see a one-time startup warning advising the migration to `HYDROLIX_URL`. In-cluster (o6r-managed) deployments will not see this warning; their migration is handled by the platform.
 

--- a/mcp_hydrolix/mcp_env.py
+++ b/mcp_hydrolix/mcp_env.py
@@ -17,25 +17,27 @@ logger = logging.getLogger("mcp-hydrolix")
 
 
 # Mapping of deprecated env var names to their replacements.
-# Transitional — will be REMOVED when the five deprecated aliases are dropped.
+# Transitional — will be REMOVED when the deprecated aliases are dropped.
 ALIAS_RENAMES: dict[str, str] = {
     "HYDROLIX_HOST": "HYDROLIX_HTTP_QUERY_HOST",
     "HYDROLIX_PORT": "HYDROLIX_HTTP_QUERY_PORT",
     "HYDROLIX_SECURE": "HYDROLIX_HTTP_QUERY_SECURE",
     "HYDROLIX_API_HOST": "HYDROLIX_VERSION_API_HOST",
     "HYDROLIX_API_PORT": "HYDROLIX_VERSION_API_PORT",
+    "HYDROLIX_PROXY_PATH": "HYDROLIX_HTTP_QUERY_PATH",
 }
 DEPRECATED_ALIASES: tuple[str, ...] = tuple(ALIAS_RENAMES.keys())
 
 
 def _external_deprecation_log(aliases: list[str]) -> str:
     """Build the external-audience startup WARNING (server log; operator-facing)."""
+    pairs = ", ".join(f"{old} -> {ALIAS_RENAMES[old]}" for old in aliases)
     return (
         f"Deprecated Hydrolix environment variable(s) detected: {', '.join(aliases)}. "
-        "These will be removed in a future release. "
+        f"These will be removed in a future release; each has a direct replacement ({pairs}). "
         "For typical external deployments, setting HYDROLIX_URL alone "
-        "(e.g. HYDROLIX_URL=https://mycluster.hydrolix.live) is sufficient "
-        "and replaces all of these variables."
+        "(e.g. HYDROLIX_URL=https://mycluster.hydrolix.live) covers the "
+        "connection-target variables (host, port, TLS)."
     )
 
 
@@ -51,9 +53,10 @@ def _external_deprecation_instructions(aliases: list[str]) -> str:
         f"variable(s): {', '.join(aliases)}. They will be removed in a future "
         "release. Please tell the user about this and encourage them to contact "
         "their Hydrolix operator (whoever administers this MCP server's "
-        "configuration) to replace these deprecated variables with HYDROLIX_URL "
-        "(e.g. HYDROLIX_URL=https://mycluster.hydrolix.live), which alone is "
-        "sufficient for typical external deployments."
+        "configuration) to migrate to the current variable names. For typical "
+        "external deployments, HYDROLIX_URL alone "
+        "(e.g. HYDROLIX_URL=https://mycluster.hydrolix.live) covers the "
+        "connection target (host, port, TLS)."
     )
 
 
@@ -145,8 +148,9 @@ class HydrolixConfig:
         HYDROLIX_HTTP_QUERY_SECURE: Override the query TLS flag
             (precedence: this > HYDROLIX_SECURE > URL scheme == "https" > True).
         HYDROLIX_HTTP_QUERY_PATH: Override the query request path
-            (precedence: this > hard default "/query"). Set to "/" (or empty) for
-            direct / in-cluster targets that serve queries at the root.
+            (precedence: this > HYDROLIX_PROXY_PATH > hard default "/query"). Set
+            to "/" (or empty) for direct / in-cluster targets that serve queries
+            at the root.
 
     Endpoint overrides (REST ``/version`` probe):
         HYDROLIX_VERSION_API_HOST: Override the version-api hostname
@@ -159,7 +163,7 @@ class HydrolixConfig:
 
     Deprecated environment variables (still honored during the transition window):
         HYDROLIX_HOST, HYDROLIX_PORT, HYDROLIX_SECURE,
-        HYDROLIX_API_HOST, HYDROLIX_API_PORT
+        HYDROLIX_API_HOST, HYDROLIX_API_PORT, HYDROLIX_PROXY_PATH
 
     Optional environment variables (with defaults):
         HYDROLIX_TOKEN: Service account token to the Hydrolix Server (this or user+password is required)
@@ -295,9 +299,14 @@ class HydrolixConfig:
         Leading slashes are normalized by clickhouse-connect, so ``/query`` and
         ``query`` are equivalent.
 
-        Precedence: HYDROLIX_HTTP_QUERY_PATH > hard default "/query".
+        Precedence: HYDROLIX_HTTP_QUERY_PATH > HYDROLIX_PROXY_PATH (deprecated) >
+        hard default "/query".
         """
-        return os.getenv("HYDROLIX_HTTP_QUERY_PATH", "/query")
+        if (raw := os.getenv("HYDROLIX_HTTP_QUERY_PATH")) is not None:
+            return raw
+        if (raw := os.getenv("HYDROLIX_PROXY_PATH")) is not None:
+            return raw
+        return "/query"
 
     @property
     def version_api_host(self) -> str:

--- a/mcp_hydrolix/mcp_env.py
+++ b/mcp_hydrolix/mcp_env.py
@@ -144,6 +144,9 @@ class HydrolixConfig:
             (precedence: this > HYDROLIX_PORT > URL scheme default > 8088).
         HYDROLIX_HTTP_QUERY_SECURE: Override the query TLS flag
             (precedence: this > HYDROLIX_SECURE > URL scheme == "https" > True).
+        HYDROLIX_HTTP_QUERY_PATH: Override the query request path
+            (precedence: this > hard default "/query"). Set to "/" (or empty) for
+            direct / in-cluster targets that serve queries at the root.
 
     Endpoint overrides (REST ``/version`` probe):
         HYDROLIX_VERSION_API_HOST: Override the version-api hostname
@@ -279,6 +282,22 @@ class HydrolixConfig:
         if self._parsed_url is not None:
             return self._parsed_url.scheme == "https"
         return True
+
+    @property
+    def query_path(self) -> str:
+        """Get the HTTP request path for the ClickHouse query endpoint.
+
+        When mcp-hydrolix is used from *outside* the cluster, traffic goes through
+        Traefik, which serves the ClickHouse HTTP query engine under ``/query``
+        rather than at the root ``/``. Defaulting to ``/query`` means
+        ``HYDROLIX_URL`` alone works for external deployments; set to ``/`` (or
+        empty) for direct / in-cluster targets that serve queries at the root.
+        Leading slashes are normalized by clickhouse-connect, so ``/query`` and
+        ``query`` are equivalent.
+
+        Precedence: HYDROLIX_HTTP_QUERY_PATH > hard default "/query".
+        """
+        return os.getenv("HYDROLIX_HTTP_QUERY_PATH", "/query")
 
     @property
     def version_api_host(self) -> str:
@@ -567,6 +586,11 @@ class HydrolixConfig:
             "host": self.host,
             "port": self.port,
             "secure": self.secure,
+            # clickhouse-connect appends proxy_path to the base URL for every
+            # request (self.url = "{scheme}://{host}:{port}{proxy_path}"), so this
+            # is how we route queries to Hydrolix's Traefik "/query" path when
+            # reaching the cluster from outside. See the query_path property.
+            "proxy_path": self.query_path,
             "verify": self.verify,
             "connect_timeout": self.connect_timeout,
             "send_receive_timeout": self.send_receive_timeout,

--- a/tests/test_mcp_env.py
+++ b/tests/test_mcp_env.py
@@ -386,6 +386,24 @@ class TestQueryPath:
         cfg = HydrolixConfig().get_client_config(None)
         assert cfg["proxy_path"] == "/query-head"
 
+    def test_deprecated_alias_honored(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # A pre-#133 config using HYDROLIX_PROXY_PATH still works.
+        monkeypatch.setenv("HYDROLIX_URL", "https://cluster.example.com")
+        monkeypatch.setenv("HYDROLIX_PROXY_PATH", "/legacy")
+        assert HydrolixConfig().query_path == "/legacy"
+
+    def test_new_var_wins_over_deprecated_alias(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HYDROLIX_URL", "https://cluster.example.com")
+        monkeypatch.setenv("HYDROLIX_HTTP_QUERY_PATH", "/query")
+        monkeypatch.setenv("HYDROLIX_PROXY_PATH", "/legacy")
+        assert HydrolixConfig().query_path == "/query"
+
+    def test_deprecated_alias_empty_is_honored(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Empty string is an explicit value for the alias too (root path).
+        monkeypatch.setenv("HYDROLIX_URL", "https://cluster.example.com")
+        monkeypatch.setenv("HYDROLIX_PROXY_PATH", "")
+        assert HydrolixConfig().query_path == ""
+
 
 class TestVersionApiHostAndPort:
     def test_inherits_from_url(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_mcp_env.py
+++ b/tests/test_mcp_env.py
@@ -249,6 +249,7 @@ class TestExternalSufficiency:
         assert c.version_api_host == "cluster.example.com"
         assert c.version_api_port == 443
         assert c.version_api_secure is True
+        assert c.query_path == "/query"
 
     def test_url_alone_http_scheme(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("HYDROLIX_URL", "http://cluster.example.com")
@@ -346,6 +347,44 @@ class TestSecurePrecedence:
         monkeypatch.setenv("HYDROLIX_URL", "https://cluster.example.com")
         monkeypatch.setenv("HYDROLIX_SECURE", "false")
         assert HydrolixConfig().secure is False
+
+
+class TestQueryPath:
+    def test_default_is_query(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HYDROLIX_URL", "https://cluster.example.com")
+        assert HydrolixConfig().query_path == "/query"
+
+    def test_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HYDROLIX_URL", "https://cluster.example.com")
+        monkeypatch.setenv("HYDROLIX_HTTP_QUERY_PATH", "/custom/query")
+        assert HydrolixConfig().query_path == "/custom/query"
+
+    def test_override_to_root(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HYDROLIX_URL", "https://cluster.example.com")
+        monkeypatch.setenv("HYDROLIX_HTTP_QUERY_PATH", "/")
+        assert HydrolixConfig().query_path == "/"
+
+    def test_override_to_empty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Empty string is an explicit override (falls back to the default only
+        # when the var is unset), letting root-path targets opt out of "/query".
+        monkeypatch.setenv("HYDROLIX_URL", "https://cluster.example.com")
+        monkeypatch.setenv("HYDROLIX_HTTP_QUERY_PATH", "")
+        assert HydrolixConfig().query_path == ""
+
+    def test_included_in_client_config(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HYDROLIX_URL", "https://cluster.example.com")
+        monkeypatch.setenv("HYDROLIX_USER", "u")
+        monkeypatch.setenv("HYDROLIX_PASSWORD", "p")
+        cfg = HydrolixConfig().get_client_config(None)
+        assert cfg["proxy_path"] == "/query"
+
+    def test_client_config_reflects_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HYDROLIX_URL", "https://cluster.example.com")
+        monkeypatch.setenv("HYDROLIX_USER", "u")
+        monkeypatch.setenv("HYDROLIX_PASSWORD", "p")
+        monkeypatch.setenv("HYDROLIX_HTTP_QUERY_PATH", "/query-head")
+        cfg = HydrolixConfig().get_client_config(None)
+        assert cfg["proxy_path"] == "/query-head"
 
 
 class TestVersionApiHostAndPort:


### PR DESCRIPTION
## What

Adds a `HYDROLIX_HTTP_QUERY_PATH` env var (default `/query`) that sets the HTTP
request path for the ClickHouse query endpoint, wired into the clickhouse-connect
client via its `proxy_path` kwarg (originally assumed unused)

## Why

`HYDROLIX_URL`-derived connection config (#113) left the query path at
clickhouse-connect's default `/`. Reaching a cluster from *outside* goes through
Traefik, which serves the query engine under `/query` — so `https://<cluster>/`
hits the web front-end and returns `405 Method Not Allowed`. Defaulting the path
to `/query` makes `HYDROLIX_URL` alone work for external/proxied deployments.

## Scope / not in scope

- Path-only change; the URL-derived port is untouched. Against a live cluster
  `:8088/query`, `:443/query`, and `:8088/` all work — only `:443/` (the new default) was broken.
- No operator/Helm change: in-cluster the operator injects host aliases
  (`HYDROLIX_HOST=query-head`) that bypass Traefik, so this only affects
  external users.
- Setting `HYDROLIX_HTTP_QUERY_PATH=/` (or empty) restores root-path behavior
  for direct / in-cluster targets.

## Changes

- `mcp_env.py`: new `query_path` property; passed as `proxy_path` in `get_client_config`.
- `README.md`: documented under Endpoint overrides.
- `tests/test_mcp_env.py`: `TestQueryPath` + extended URL-alone sufficiency test.

## Testing

- `tests/test_mcp_env.py`: 75/75 pass.
- End-to-end against qe-innovations-2: default `/query` → `SELECT version()`
  succeeds (`25.8.23.1`); forcing `/` reproduces the `405`.

Closes HDX-11831.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
