### PR TITLE
[IL][HDX-11826] Correct HYDROLIX_QUERY_HEAD_POOL docs: it names a pool, not a database

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -81,9 +81,8 @@ These map to per-query Hydrolix/ClickHouse settings sent with every query:
   * In platform-managed (in-cluster) deployments the cluster tunable is mapped onto this same variable; the deployment owns the environment, so its value is authoritative
 * `HYDROLIX_QUERY_HEAD_POOL`: Name of the Hydrolix query-head pool to route this connection to
   * Default: None (uses the cluster's default query head)
-  * Unlike `HYDROLIX_QUERY_POOL` (a per-query setting for the query *peer* pool), query-head pool selection is connection-time routing keyed on the database name: the value is sent as the connection's default database (the `?database=` parameter), which CHProxy matches against the operator-configured routing rules to pick a query-head pool. It is therefore a database name those rules map to a pool, not necessarily a literal pool name
-  * The value must name a database that **already exists** on the cluster. Because the routing key doubles as the ClickHouse default database, a non-existent value can cause the query-head to reject the connection
-  * Only meaningful when query-head pooling (CHProxy) is enabled on the cluster. If it is not, no routing occurs and the value is simply the connection's default database — harmless when it is a real database (queries are fully qualified `db.table`, so the default is unused for name resolution). Leave this unset on clusters without query-head pooling
+  * The pool must be preconfigured on the cluster; requests fail if it doesn't exist
+  * Unlike `HYDROLIX_QUERY_POOL`, which selects the query *peer* pool per query, this selects the query-head pool for the whole connection
 * `HYDROLIX_HTTPS_PROXY` / `HYDROLIX_HTTP_PROXY`: Outbound proxy for reaching the Hydrolix cluster
   * Default: None (connect directly)
   * Set one to route the connection through a corporate proxy; include the scheme, e.g. `http://proxy.corp:8080`. If both are set, `HYDROLIX_HTTPS_PROXY` wins

--- a/mcp_hydrolix/mcp_env.py
+++ b/mcp_hydrolix/mcp_env.py
@@ -208,14 +208,9 @@ class HydrolixConfig:
             authoritative. (default: None -- use the cluster default pool)
         HYDROLIX_QUERY_HEAD_POOL: Name of the Hydrolix query-head pool to route this connection
             to. Unlike HYDROLIX_QUERY_POOL (a per-query ``hdx_query_pool_name`` setting selecting
-            the query *peer* pool), query-head pool selection is connection-time routing keyed on
-            the *database name*: the value is sent as the connection's default database (the
-            ``?database=`` parameter on the HTTP path), which CHProxy matches against the
-            operator-configured routing rules to pick a query-head pool. It is therefore a
-            database name that those rules map to a pool, not necessarily a literal pool name.
-            When set it becomes the connection's default database; this is safe because the
-            server issues fully-qualified ``db.table`` queries, so the default database is
-            unused for name resolution. (default: None -- use the cluster default query head)
+            the query *peer* pool), this selects the query-head pool for the whole connection.
+            The pool must be preconfigured on the cluster; requests fail if it does not exist.
+            (default: None -- use the cluster default query head)
         HYDROLIX_HTTPS_PROXY / HYDROLIX_HTTP_PROXY: Outbound proxy for reaching the cluster.
             Set one (https wins if both are set) to route the connection through a corporate
             proxy; include the scheme (e.g. http://proxy.corp:8080). This is the single egress
@@ -572,31 +567,23 @@ class HydrolixConfig:
 
     @property
     def query_head_pool(self) -> Optional[str]:
-        """Get the Hydrolix query-head pool routing key for this connection.
+        """Get the Hydrolix query-head pool name for this connection.
 
-        Query-head pool selection is connection-time routing keyed on the database
-        name, not a per-query setting (contrast :pyattr:`query_pool`, which selects
-        the query *peer* pool via ``hdx_query_pool_name``). The value is sent as the
-        connection's default database -- the ``?database=`` parameter on the HTTP
-        path -- and CHProxy matches it against the operator-configured routing
-        rules to select a query-head pool. It is thus a database name the
-        routing rules map to a pool, not necessarily a literal pool name.
+        Unlike :pyattr:`query_pool` (a per-query ``hdx_query_pool_name`` setting
+        selecting the query *peer* pool), this selects the query-head pool for
+        the whole connection. The pool must be preconfigured on the cluster;
+        requests fail if it does not exist. No validation is performed here --
+        that is an operator/deployment concern.
 
-        When set, this becomes the connection default database (see
-        ``get_client_config``). That is safe because the server issues
-        fully-qualified ``db.table`` queries, so the default database is not used
-        for name resolution -- it serves only as the routing key here.
-
-        The value must name a database that already exists on the cluster: since
-        the routing key doubles as the ClickHouse default database, a non-existent
-        value can make the query-head reject the connection. This is only
-        meaningful when query-head pooling (CHProxy) is enabled; without it no
-        routing happens and the value is just the default database (a no-op when
-        it is a real database). Same "must already exist" contract as query pools;
-        no validation is performed here -- it is an operator/deployment concern.
+        Implementation detail: the value reaches the cluster via the HTTP
+        ``database`` parameter (see ``get_client_config``). Query-head pools
+        have nothing to do with databases; the parameter is just the transport
+        for the pool name. It is free for that purpose because the server sends
+        only fully-qualified ``db.table`` queries -- database selection never
+        rides on the connection.
 
         A blank/whitespace value is treated as unset so that MCPB hosts injecting
-        empty user_config fields do not send an empty routing key.
+        empty user_config fields do not send an empty pool name.
         """
         return os.getenv("HYDROLIX_QUERY_HEAD_POOL", "").strip() or None
 
@@ -739,11 +726,11 @@ class HydrolixConfig:
             "tz_mode": "aware",
         }
 
-        # Set the connection's default database. HYDROLIX_QUERY_HEAD_POOL is the
-        # query-head routing key, sent as ?database=. Safe because queries are
-        # fully-qualified, so the default database is unused for name resolution.
-        if routing_database := self.query_head_pool:
-            config["database"] = routing_database
+        # HYDROLIX_QUERY_HEAD_POOL rides the HTTP ?database= parameter -- the
+        # cluster reads the pool name from it. Free for that purpose because
+        # queries are always fully-qualified db.table.
+        if head_pool := self.query_head_pool:
+            config["database"] = head_pool
 
         # Add credentials
         config |= self.creds_with(request_credential).clickhouse_config_entries()

--- a/tests/test_mcp_env.py
+++ b/tests/test_mcp_env.py
@@ -176,12 +176,12 @@ class TestQueryPool:
 
 
 class TestQueryHeadPool:
-    """HYDROLIX_QUERY_HEAD_POOL resolution and its effect on the connection's
-    default database (the ?database= routing key).
+    """HYDROLIX_QUERY_HEAD_POOL resolution and how the pool name is conveyed.
 
     The property itself mirrors query_pool (None/value/blank/whitespace). The
-    routing tests exercise get_client_config, where the head pool -- when set --
-    drives the ``database`` slot.
+    routing tests exercise get_client_config, where the pool name -- when set --
+    rides the HTTP ``database`` parameter (an implementation detail; query-head
+    pools are unrelated to databases).
     """
 
     def test_default_is_none(self, config: HydrolixConfig) -> None:


### PR DESCRIPTION
What does this PR do?
-----------------------

Corrects the documented semantics of `HYDROLIX_QUERY_HEAD_POOL` everywhere they appear (docs/CONFIG.md, the `mcp_env` module docstring, the `query_head_pool` property docstring, and a test class docstring):

- The value is the **name of a query head pool**, preconfigured out-of-band on the cluster.
- **Requests fail if the named pool doesn't exist.** Earlier text framed the value as a database-name routing key that need not match a real pool, and claimed unmatched values were harmless — both wrong.
- The HTTP `database` parameter is only the transport for the pool name (query-head pools have nothing to do with databases), so user-facing docs no longer mention it. It remains documented as an implementation detail at the `get_client_config` wiring, where a developer needs it.

Also trims the CONFIG.md entry accordingly (file shrinks by ~800 bytes). No behavior change.

Does this PR meet the acceptance criteria?
--------------------------------------------

* [x] Documentation created/updated
* [ ] Tests added for this feature/bug (docs-only; no behavior change — existing `TestQueryHeadPool` still covers the wiring)
* [ ] Does this change request have any security impacts? No

Testing
--------------------------------------------

`uv run pytest tests/test_mcp_env.py` — 120 passed. Docstring/markdown changes only; no runtime code paths altered (one local variable renamed in `get_client_config`, covered by the existing head-pool routing tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)