### PR TITLE
Correct HYDROLIX_QUERY_HEAD_POOL fallback semantics

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -81,7 +81,7 @@ These map to per-query Hydrolix/ClickHouse settings sent with every query:
   * In platform-managed (in-cluster) deployments the cluster tunable is mapped onto this same variable; the deployment owns the environment, so its value is authoritative
 * `HYDROLIX_QUERY_HEAD_POOL`: Name of the Hydrolix query-head pool to route this connection to
   * Default: None (uses the cluster's default query head)
-  * The pool must be preconfigured on the cluster; requests fail if it doesn't exist
+  * The pool must be preconfigured on the cluster; if the named pool isn't configured, the connection falls back to the cluster's default query head pool
   * Unlike `HYDROLIX_QUERY_POOL`, which selects the query *peer* pool per query, this selects the query-head pool for the whole connection
 * `HYDROLIX_HTTPS_PROXY` / `HYDROLIX_HTTP_PROXY`: Outbound proxy for reaching the Hydrolix cluster
   * Default: None (connect directly)

--- a/mcp_hydrolix/mcp_env.py
+++ b/mcp_hydrolix/mcp_env.py
@@ -264,7 +264,8 @@ class HydrolixConfig:
         HYDROLIX_QUERY_HEAD_POOL: Name of the Hydrolix query-head pool to route this connection
             to. Unlike HYDROLIX_QUERY_POOL (a per-query ``hdx_query_pool_name`` setting selecting
             the query *peer* pool), this selects the query-head pool for the whole connection.
-            The pool must be preconfigured on the cluster; requests fail if it does not exist.
+            The pool must be preconfigured on the cluster; if the named pool isn't configured,
+            the connection falls back to the cluster's default query head.
             (default: None -- use the cluster default query head)
         HYDROLIX_HTTPS_PROXY / HYDROLIX_HTTP_PROXY: Outbound proxy for reaching the cluster.
             Set one (https wins if both are set) to route the connection through a corporate
@@ -630,7 +631,8 @@ class HydrolixConfig:
         Unlike :pyattr:`query_pool` (a per-query ``hdx_query_pool_name`` setting
         selecting the query *peer* pool), this selects the query-head pool for
         the whole connection. The pool must be preconfigured on the cluster;
-        requests fail if it does not exist. No validation is performed here --
+        if the named pool isn't configured, the connection falls back to the
+        cluster's default query head. No validation is performed here --
         that is an operator/deployment concern.
 
         Implementation detail: the value reaches the cluster via the HTTP


### PR DESCRIPTION
What does this PR do?
-----------------------
A query-head pool name that isn't configured on the cluster does not cause requests to fail -- the connection falls back to the cluster's default query head. Per @vmiscenko and HDX-11898, replace the incorrect "requests fail if it does not exist" wording in the MCPConfig docstring, the query_head_pool property docstring, and docs/CONFIG.md.

Does this PR meet the acceptance criteria?
--------------------------------------------

* [x] Documentation created/updated
* [ ] Tests added for this feature/bug
* [ ] Does this change request have any security impacts?

Release Notes
---------------------------------------------------

* Major changes:
    *
* Minor changes:
    *
* Bugfixes:
    *
* Issues Closed:
    *
* Security impacts identified:
    *

Testing
--------------------------------------------
Verified by @vmiscenko while reviewing a PR in a different repo