### PR TITLE
[IL] Bump mcp to 1.28.1 to clear Aikido high CVEs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,9 @@ license-files = ["LICENSE"]
 requires-python = ">=3.13"
 dependencies = [
     "fastmcp>=3.3.0,<3.4",
+    # mcp is pulled in transitively via fastmcp; floor pinned to clear
+    # CVE-2026-59950 / 52870 / 52869 (all fixed in 1.28.1).
+    "mcp>=1.28.1,<2",
     "python-dotenv>=1.1,<1.3",
     "clickhouse-connect>=0.15,<0.16",
     "truststore>=0.10",

--- a/uv.lock
+++ b/uv.lock
@@ -817,7 +817,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.27.0"
+version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -835,9 +835,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/eb/c0cfc62075dc6e1ec1c64d352ae09ac051d9334311ed226f1f425312848a/mcp-1.27.0.tar.gz", hash = "sha256:d3dc35a7eec0d458c1da4976a48f982097ddaab87e278c5511d5a4a56e852b83", size = 607509, upload-time = "2026-04-02T14:48:08.88Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/46/f6b4ad632c67ef35209a66127e4bddc95759649dd595f71f13fba11bdf9a/mcp-1.27.0-py3-none-any.whl", hash = "sha256:5ce1fa81614958e267b21fb2aa34e0aea8e2c6ede60d52aba45fd47246b4d741", size = 215967, upload-time = "2026-04-02T14:48:07.24Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
 ]
 
 [[package]]
@@ -864,6 +864,7 @@ source = { editable = "." }
 dependencies = [
     { name = "clickhouse-connect" },
     { name = "fastmcp" },
+    { name = "mcp" },
     { name = "prometheus-client" },
     { name = "pyjwt" },
     { name = "python-dotenv" },
@@ -889,6 +890,7 @@ requires-dist = [
     { name = "fastmcp", specifier = ">=3.3.0,<3.4" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.27,<0.29" },
     { name = "kubernetes", marker = "extra == 'dev'", specifier = ">=30,<32" },
+    { name = "mcp", specifier = ">=1.28.1,<2" },
     { name = "mcp-clickhouse", marker = "extra == 'dev'", specifier = "==0.1.13" },
     { name = "pre-commit", marker = "extra == 'dev'" },
     { name = "prometheus-client", specifier = ">=0.21,<1.0" },
@@ -1630,8 +1632,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
## What

Bump the transitive `mcp` package (pulled in via fastmcp) from **1.27.0 → 1.28.1** to clear three high-severity Aikido CVEs:

| CVE | Severity | Fixed in |
|-----|----------|----------|
| CVE-2026-59950 | high | 1.28.1 |
| CVE-2026-52870 | high | 1.27.2 |
| CVE-2026-52869 | high | 1.27.2 |

1.28.1 supersedes all three fixes, so a single bump clears the group.

## How

- Added an explicit direct constraint `mcp>=1.28.1,<2` in `pyproject.toml`. `mcp` was previously transitive-only; declaring it directly bakes the security floor into the **published wheel metadata**, so downstream `pip install` gets the fix too — not just our `uv.lock`.
- `uv lock` re-resolves `mcp` to 1.28.1 (plus a harmless `secretstorage` platform-marker refinement).
- `fastmcp` 3.3.0 declares `mcp<2.0,>=1.24.0`, so 1.28.1 is within its supported range; nothing else caps `mcp`.

## Verification

**Unit tests:** 411 pass. Our four direct `mcp` import points (`mcp.types.ToolAnnotations` and the auth middleware/provider paths in `auth/mcp_providers.py`) all resolve under 1.28.1.

**End-to-end:** the e2e smoke suite ran against a live Hydrolix QE cluster — **6 passed, 1 gated-skip**. The harness built the working-tree image (with `mcp 1.28.1` baked in), deployed it via the operator CR, and exercised the full MCP path through cluster ingress:

- initialize handshake / tool listing
- `list_databases`, `list_tables`, `get_table_info`, `run_select_query`
- missing-auth → 401

Cluster state was restored on teardown (CR reverted, advisory lock dropped, pod rolled back to the operator-reconciled image).

## Risk

Low. Minor version move within fastmcp's declared support range; unit suite green; the exact build validated end-to-end against a real cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)